### PR TITLE
Fix missing external modules with .d.ts extension

### DIFF
--- a/lib/main/tsconfig/tsconfig.ts
+++ b/lib/main/tsconfig/tsconfig.ts
@@ -255,7 +255,13 @@ function increaseProjectForReferenceAndImports(files: string[]) {
                     .concat(
                     preProcessedFileInfo.importedFiles
                         .filter((fileReference) => pathIsRelative(fileReference.filename))
-                        .map(fileReference => path.resolve(dir, fileReference.filename + '.ts'))
+                        .map(fileReference => {
+                            var file = path.resolve(dir, fileReference.filename + '.ts');
+                            if (!fs.existsSync(file)) {
+                                file = path.resolve(dir, fileReference.filename + '.d.ts');
+                            }
+                            return file;
+                        })
                     )
                 );
         });


### PR DESCRIPTION
The TypeScript compiler will look for files with both `.ts` and `.d.ts` extensions when resolving external imports, so atom-typescript also needs to do this.

I didn’t check to see if the existsSync check is really necessary or if this could just be updated to double up the number of files in the map, but I did verify this fixes the problem where you `import foo = require('./foo')` and the file is `foo.d.ts`.