### PR TITLE
Allow "out" CompilerOption to be relative path to project.

### DIFF
--- a/lib/main/tsconfig/tsconfig.js
+++ b/lib/main/tsconfig/tsconfig.js
@@ -82,6 +82,9 @@ function rawToTsCompilerOptions(jsonOptions, projectDir) {
     if (compilerOptions.outDir !== undefined) {
         compilerOptions.outDir = path.resolve(projectDir, compilerOptions.outDir);
     }
+    if (compilerOptions.out !== undefined) {
+        compilerOptions.out = path.resolve(projectDir, compilerOptions.out);
+    }
     return compilerOptions;
 }
 function tsToRawCompilerOptions(compilerOptions) {

--- a/lib/main/tsconfig/tsconfig.ts
+++ b/lib/main/tsconfig/tsconfig.ts
@@ -162,6 +162,10 @@ function rawToTsCompilerOptions(jsonOptions: CompilerOptions, projectDir: string
         compilerOptions.outDir = path.resolve(projectDir, compilerOptions.outDir);
     }
 
+    if (compilerOptions.out !== undefined) {
+        compilerOptions.out = path.resolve(projectDir, compilerOptions.out);
+    }
+
     return compilerOptions;
 }
 


### PR DESCRIPTION
Fixes #100.

Resolves the out parameter to be relative to the project.

Previously, it would be relative to the Users profile directory. 