### PR TITLE
Make keybinds more specific

### DIFF
--- a/keymaps/atom-typescript.cson
+++ b/keymaps/atom-typescript.cson
@@ -1,4 +1,4 @@
-'atom-text-editor[data-grammar~=ts]':
+'atom-workspace atom-text-editor:not([mini])[data-grammar~=ts]':
   'alt-cmd-l': 'typescript:format-code'
   'alt-ctrl-l': 'typescript:format-code'
   'ctrl-;': 'typescript:context-actions'


### PR DESCRIPTION
Keybind for quick fix was not specific enough to override the default core `editor:newline` rule
@basarat 