### PR TITLE
Don't include the default lib when using the noLib flag

### DIFF
--- a/dist/main/lang/core/languageServiceHost2.js
+++ b/dist/main/lang/core/languageServiceHost2.js
@@ -118,8 +118,8 @@ function getScriptSnapShot(scriptInfo) {
         version: version
     };
 }
-exports.defaultLibFile = function (target) {
-    var filename = target === 2 ? "lib.es6.d.ts" : "lib.d.ts";
+exports.getDefaultLibFilePath = function (options) {
+    var filename = ts.getDefaultLibFileName(options);
     return (path.join(path.dirname(require.resolve('typescript')), filename)).split('\\').join('/');
 };
 exports.typescriptDirectory = path.dirname(require.resolve('typescript')).split('\\').join('/');
@@ -229,11 +229,11 @@ var LanguageServiceHost = (function () {
         this.getCurrentDirectory = function () {
             return _this.config.projectFileDirectory;
         };
-        this.getDefaultLibFileName = function () {
-            return _this.config.project.compilerOptions.target === 2 ? "lib.es6.d.ts" : "lib.d.ts";
-        };
+        this.getDefaultLibFileName = ts.getDefaultLibFileName;
         config.project.files.forEach(function (file) { return _this.addScript(file); });
-        this.addScript(exports.defaultLibFile(config.project.compilerOptions.target));
+        if (!config.project.compilerOptions.noLib) {
+            this.addScript(exports.getDefaultLibFilePath(config.project.compilerOptions));
+        }
     }
     return LanguageServiceHost;
 })();

--- a/dist/main/lang/core/project.js
+++ b/dist/main/lang/core/project.js
@@ -6,7 +6,7 @@ var Project = (function () {
         this.languageService = ts.createLanguageService(this.languageServiceHost, ts.createDocumentRegistry());
     }
     Project.prototype.getProjectSourceFiles = function () {
-        var libFile = exports.languageServiceHost.defaultLibFile(this.projectFile.project.compilerOptions.target);
+        var libFile = exports.languageServiceHost.getDefaultLibFilePath(this.projectFile.project.compilerOptions);
         var files = this.languageService.getProgram().getSourceFiles().filter(function (x) { return x.fileName !== libFile; });
         return files;
     };

--- a/lib/main/lang/core/languageServiceHost2.ts
+++ b/lib/main/lang/core/languageServiceHost2.ts
@@ -204,8 +204,8 @@ function getScriptSnapShot(scriptInfo: ScriptInfo): ts.IScriptSnapshot {
     }
 }
 
-export var defaultLibFile = (target: ts.ScriptTarget) => {
-    var filename = target === ts.ScriptTarget.ES6 ? "lib.es6.d.ts" : "lib.d.ts";
+export var getDefaultLibFilePath = (options: ts.CompilerOptions) => {
+    var filename = ts.getDefaultLibFileName(options);
     return (path.join(path.dirname(require.resolve('typescript')), filename)).split('\\').join('/');
 }
 
@@ -227,7 +227,9 @@ export class LanguageServiceHost implements ts.LanguageServiceHost {
         config.project.files.forEach((file) => this.addScript(file));
 
         // Also add the `lib.d.ts`
-        this.addScript(defaultLibFile(config.project.compilerOptions.target));
+        if (!config.project.compilerOptions.noLib) {
+          this.addScript(getDefaultLibFilePath(config.project.compilerOptions));
+        }
     }
 
     addScript = (fileName: string, content?: string) => {
@@ -353,7 +355,5 @@ export class LanguageServiceHost implements ts.LanguageServiceHost {
     getCurrentDirectory = (): string  => {
         return this.config.projectFileDirectory;
     }
-    getDefaultLibFileName = (): string => {
-        return this.config.project.compilerOptions.target === ts.ScriptTarget.ES6 ? "lib.es6.d.ts" : "lib.d.ts";
-    }
+    getDefaultLibFileName = ts.getDefaultLibFileName;
 }

--- a/lib/main/lang/core/project.ts
+++ b/lib/main/lang/core/project.ts
@@ -22,7 +22,7 @@ export class Project {
 
     /** all files except lib.d.ts  */
     public getProjectSourceFiles(): ts.SourceFile[] {
-        var libFile = languageServiceHost.defaultLibFile(this.projectFile.project.compilerOptions.target);
+        var libFile = languageServiceHost.getDefaultLibFilePath(this.projectFile.project.compilerOptions);
         var files
             = this.languageService.getProgram().getSourceFiles().filter(x=> x.fileName !== libFile);
         return files;


### PR DESCRIPTION
The default lib shouldn't be included when the noLib flag is set. This is the same behavior as the tsc command: https://github.com/Microsoft/TypeScript/blob/master/src/compiler/program.ts#L155