### PR TITLE
Error panel UI tweak

### DIFF
--- a/dist/main/atom/views/mainPanelView.js
+++ b/dist/main/atom/views/mainPanelView.js
@@ -39,13 +39,15 @@ var MainPanelView = (function (_super) {
         }, function () {
             _this.div({
                 class: 'panel-resize-handle',
-                style: 'position: absolute; top: 0; left: 0; right: 0; height: 10px; cursor: row-resize; z-index: 3'
+                style: 'position: absolute; top: 0; left: 0; right: 0; height: 10px; cursor: row-resize; z-index: 3; -webkit-user-select:none'
             });
             _this.div({
-                class: 'panel-heading layout horizontal'
+                class: 'panel-heading layout horizontal',
+                style: '-webkit-user-select:none',
+                dblclick: 'toggle'
             }, function () {
                 _this.span({
-                    style: 'cursor: pointer; color: rgb(0, 148, 255)',
+                    style: 'cursor: pointer; color: rgb(0, 148, 255); -webkit-user-select:none',
                     click: 'toggle'
                 }, function () {
                     _this.span({ class: "icon-microscope" });

--- a/lib/main/atom/views/mainPanelView.ts
+++ b/lib/main/atom/views/mainPanelView.ts
@@ -49,13 +49,15 @@ export class MainPanelView extends view.View<any> {
         }, () => {
                 this.div({
                     class: 'panel-resize-handle',
-                    style: 'position: absolute; top: 0; left: 0; right: 0; height: 10px; cursor: row-resize; z-index: 3'
+                    style: 'position: absolute; top: 0; left: 0; right: 0; height: 10px; cursor: row-resize; z-index: 3; -webkit-user-select:none'
                 });
                 this.div({
-                    class: 'panel-heading layout horizontal'
+                    class: 'panel-heading layout horizontal',
+                    style: '-webkit-user-select:none',
+                    dblclick: 'toggle'
                 }, () => {
                         this.span({
-                            style: 'cursor: pointer; color: rgb(0, 148, 255)',
+                            style: 'cursor: pointer; color: rgb(0, 148, 255); -webkit-user-select:none',
                             click: 'toggle'
                         }, () => {
                                 this.span({ class: "icon-microscope" });
@@ -77,13 +79,13 @@ export class MainPanelView extends view.View<any> {
                             style: 'display:inline-block; margin-left:5px; max-height:12px; overflow: hidden; white-space:nowrap; text-overflow: ellipsis',
                             outlet: 'summary'
                         });
-                        
+
                         this.progress({
                             class: 'inline-block build-progress',
                             style: 'display: none; color:red',
                             outlet: 'buildProgress'
                         });
-                        
+
                         this.span({ class: 'section-pending', outlet: 'sectionPending' }, () => {
                             this.span({
                                 outlet: 'txtPendingCount',


### PR DESCRIPTION
I updated the panel heading to disallow text selecting (make it more like a proper app).  You can still select text in the actual error area.  I also made the heading toggle on double-click (same behavior as single-click on the heading-fold button.  Please merge if you think this is cool.