### PR TITLE
Fix #379

### DIFF
--- a/dist/main/atom/tooltipManager.js
+++ b/dist/main/atom/tooltipManager.js
@@ -43,11 +43,7 @@ function attach(editorView, editor) {
     });
     subscriber.subscribe(scroll, 'mouseout', function (e) { return clearExprTypeTimeout(); });
     subscriber.subscribe(scroll, 'keydown', function (e) { return clearExprTypeTimeout(); });
-    atom.commands.add('atom-text-editor', 'editor:will-be-removed', function (e) {
-        if (e.currentTarget == editorView[0]) {
-            deactivate();
-        }
-    });
+    editor.onDidDestroy(function () { return deactivate(); });
     function showExpressionType(e) {
         if (exprTypeTooltip)
             return;

--- a/lib/main/atom/tooltipManager.ts
+++ b/lib/main/atom/tooltipManager.ts
@@ -61,12 +61,7 @@ export function attach(editorView: JQuery, editor: AtomCore.IEditor) {
     subscriber.subscribe(scroll, 'keydown', (e) => clearExprTypeTimeout());
 
     // Setup for clearing
-    atom.commands.add('atom-text-editor', 'editor:will-be-removed', (e) => {
-        if (e.currentTarget == editorView[0]) {
-            deactivate();
-        }
-    });
-
+    editor.onDidDestroy(() => deactivate());
 
     function showExpressionType(e: MouseEvent) {
 


### PR DESCRIPTION
The unsubscribe function is called properly now when an editor is destroyed.