### PR TITLE
End variable declarations on of keyword for ES6 loops. Fixes #451.

### DIFF
--- a/grammars/typescript.cson
+++ b/grammars/typescript.cson
@@ -30,7 +30,7 @@
     'beginCaptures':
       '1':
         'name': 'storage.modifier.js'
-    'end': '(;)|\\b(in)\\b|(?<!,|^)$'
+    'end': '(;)|\\b(in|of)\\b|(?<!,|^)$'
     'endCaptures':
       '1':
         'name': 'punctuation.terminator.statement.js'
@@ -39,7 +39,7 @@
     'patterns': [
       {
         'begin': '(?<=^|,|\\G)'
-        'end': '(,)|(?=;|\\bin\\b)|(?<!,|^)$'
+        'end': '(,)|(?=;|\\b(?:in|of)\\b)|(?<!,|^)$'
         'endCaptures':
           '1':
             'include': '#comma'


### PR DESCRIPTION
Before:

![screen shot 2015-07-10 at 15 26 18](https://cloud.githubusercontent.com/assets/5256300/8619518/14b24802-2718-11e5-8754-ad7a761d948f.png)

After:

![screen shot 2015-07-10 at 15 26 07](https://cloud.githubusercontent.com/assets/5256300/8619516/12ffe3b6-2718-11e5-8249-b10411ffc812.png)