### PR TITLE
Adds support to generate Interface Declaration from JSON like data

### DIFF
--- a/lib/main/atom/commands/commands.ts
+++ b/lib/main/atom/commands/commands.ts
@@ -24,6 +24,7 @@ import escapeHtml = require('escape-html');
 import * as rView from "../views/rView";
 import {$} from "atom-space-pen-views";
 import {registerReactCommands} from "./reactCommands";
+import {registerJson2dtsCommands} from "./json2dtsCommands";
 
 // Load all the web components
 export * from "../components/componentRegistry";
@@ -34,6 +35,7 @@ export function registerCommands() {
     outputFileCommands.register();
     registerRenameHandling();
     registerReactCommands();
+    registerJson2dtsCommands();
 
     function applyRefactorings(refactorings: RefactoringsByFilePath) {
         var paths = atomUtils.getOpenTypeScritEditorsConsistentPaths();

--- a/lib/main/atom/commands/json2dtsCommands.ts
+++ b/lib/main/atom/commands/json2dtsCommands.ts
@@ -1,0 +1,19 @@
+import * as atomUtils from "../atomUtils";
+import * as parent from "../../../worker/parent";
+import * as path from "path";
+import {convert} from "../../json2dts/json2dts";
+
+/**
+ * register commands
+ */
+export function registerJson2dtsCommands() {
+    atom.commands.add('atom-workspace', 'typescript:JSON-to-Definition', (e) => {
+        if (!atomUtils.commandForTypeScript(e)) return;
+        var editor = atom.workspace.getActiveTextEditor();
+        var filePath = editor.getPath();
+        var selection = editor.getSelectedBufferRange();
+        var text = editor.getSelectedText();
+        var range = editor.getSelectedBufferRange();
+        editor.setTextInBufferRange(range, convert(text));
+    });
+}

--- a/lib/main/json2dts/json2dts.ts
+++ b/lib/main/json2dts/json2dts.ts
@@ -1,0 +1,22 @@
+
+import JSON2DTS = require("json2dts");
+var Json2dts = (<any>JSON2DTS).Json2dts;
+var toValidJSON = (<any>JSON2DTS).toValidJSON;
+
+export function convert(content: string) {
+    try {
+        var converter = new Json2dts();
+        var text2Obj = JSON.parse(toValidJSON(content));
+        if (typeof text2Obj != "string") {
+            converter.parse(text2Obj, 'RootJson');
+            content = converter.getCode();
+        }
+        else {
+            atom.notifications.addError('Json2dts Invalid JSON');
+        }
+
+    } catch (e) {
+        atom.notifications.addError(`Json2dts Invalid JSON error: ${e}`);
+    }
+    return content;
+}

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "glob-expand": "0.0.2",
     "htmltojsx": "^0.2.2",
     "immutable": "^3.7.3",
+    "json2dts": "0.0.1",
     "mkdirp": "^0.5.0",
     "ntypescript": "1.201507091536.1",
     "react": "^0.13.3",


### PR DESCRIPTION
This adds support to generate Interface Declaration from JSON like data.

Basically is a port from [json2dts](http://xperiments.in/json2dts/) and old project...

I have tried to "clone" the same code and logic found in the HTMLtoJSX, but I am not sure that populating the "main" directory with command dependencies is a good idea.

