### PR TITLE
:bug: fix comment string as pointed out in #507

### DIFF
--- a/settings/language-typescript.cson
+++ b/settings/language-typescript.cson
@@ -1,0 +1,12 @@
+'.source.ts':
+  'editor':
+    'commentStart': '// '
+    'foldEndPattern': '^\\s*\\}|^\\s*\\]|^\\s*\\)'
+    'increaseIndentPattern': '(?x)
+        \\{ [^}"\']* $
+      | \\[ [^\\]"\']* $
+      | \\( [^)"\']* $
+      '
+    'decreaseIndentPattern': '(?x)
+        ^ \\s* (\\s* /[*] .* [*]/ \\s*)* [}\\])]
+      '


### PR DESCRIPTION
I have found out that the grammar relies on [`#comments`](https://github.com/TypeStrong/atom-typescript/blob/master/grammars/typescript.cson#L1292), which is in fact copied from [javascript grammar](https://github.com/atom/language-javascript/blob/master/grammars/javascript.cson). 
Adding settings (copied from javascript grammar) ensures that the `commentStartString` is set to `// `.

The grammar options taken from javascript grammar, such as `#comments` I referred to earlier, might not even be necessary, since they are already provided from js grammar, but this has to be investigated and tested further, it should be done in separate PR.