### PR TITLE
Improve babel integration

### DIFF
--- a/lib/main/lang/modules/building.ts
+++ b/lib/main/lang/modules/building.ts
@@ -47,27 +47,27 @@ export function emitFile(proj: project.Project, filePath: string): EmitOutput {
     });
 
     {
-      let sourceMapContents: {[index:string]: any} = {};
-      output.outputFiles.forEach(o => {
-          mkdirp.sync(path.dirname(o.name));
-          let additionalEmits = runExternalTranspiler(
-              filePath,
-              sourceFile.text,
-              o,
-              proj,
-              sourceMapContents
-          );
+        let sourceMapContents: {[index:string]: any} = {};
+        output.outputFiles.forEach(o => {
+            mkdirp.sync(path.dirname(o.name));
+            let additionalEmits = runExternalTranspiler(
+                filePath,
+                sourceFile.text,
+                o,
+                proj,
+                sourceMapContents
+            );
 
-          if (!sourceMapContents[o.name]) {
-              // .js.map files will be written as an "additional emit" later.
-              fs.writeFileSync(o.name, o.text, "utf8");
-          }
+            if (!sourceMapContents[o.name]) {
+                // .js.map files will be written as an "additional emit" later.
+                fs.writeFileSync(o.name, o.text, "utf8");
+            }
 
-          additionalEmits.forEach(a => {
-              mkdirp.sync(path.dirname(a.name));
-              fs.writeFileSync(a.name, a.text, "utf8");
+            additionalEmits.forEach(a => {
+                mkdirp.sync(path.dirname(a.name));
+                fs.writeFileSync(a.name, a.text, "utf8");
             })
-      });
+        });
     }
 
     var outputFiles = output.outputFiles.map((o) => o.name);
@@ -87,117 +87,117 @@ export function getRawOutput(proj: project.Project, filePath: string): ts.EmitOu
     let services = proj.languageService;
     let output : ts.EmitOutput;
     if (proj.includesSourceFile(filePath)) {
-      output = services.getEmitOutput(filePath);
+        output = services.getEmitOutput(filePath);
     } else {
-      output = {
-        outputFiles: [{name: filePath, text: Not_In_Context, writeByteOrderMark: false}],
-        emitSkipped: true
-      }
+        output = {
+            outputFiles: [{name: filePath, text: Not_In_Context, writeByteOrderMark: false}],
+            emitSkipped: true
+        }
     }
     return output;
 }
 
 function runExternalTranspiler(sourceFileName: string,
-                               sourceFileText: string,
-                               outputFile: ts.OutputFile,
-                               project: project.Project,
-                               sourceMapContents: {[index:string]: any}) : ts.OutputFile[] {
+    sourceFileText: string,
+    outputFile: ts.OutputFile,
+    project: project.Project,
+    sourceMapContents: {[index:string]: any}) : ts.OutputFile[] {
 
-  if (!isJSFile(outputFile.name) && !isJSSourceMapFile(outputFile.name)) {
-    return [];
-  }
-
-  let settings = project.projectFile.project;
-  let externalTranspiler = settings.externalTranspiler;
-  if (!externalTranspiler) {
-    return [];
-  }
-
-  if (isJSSourceMapFile(outputFile.name)) {
-    let sourceMapPayload = JSON.parse(outputFile.text);
-    let jsFileName = consistentPath(path.resolve(path.dirname(outputFile.name), sourceMapPayload.file));
-    sourceMapContents[outputFile.name] = {jsFileName: jsFileName, sourceMapPayload};
-    return [];
-  }
-
-  if (typeof externalTranspiler === 'string') {
-      externalTranspiler = {
-          name: externalTranspiler as any,
-          options: {}
-      }
-  }
-
-  if (externalTranspiler.name.toLocaleLowerCase() === "babel") {
-    if (!babel) {
-      babel = require("babel")
-    }
-
-    let babelOptions : any = assign({}, externalTranspiler.options, {
-      filename: outputFile.name
-    });
-
-    let sourceMapFileName = getJSMapNameForJSFile(outputFile.name);
-
-    if (sourceMapContents[sourceMapFileName]) {
-      babelOptions.inputSourceMap = sourceMapContents[sourceMapFileName].sourceMapPayload;
-      let baseName = path.basename(sourceFileName);
-      // NOTE: Babel generates invalid source map without consistent `sources` and `file`.
-      babelOptions.inputSourceMap.sources = [baseName];
-      babelOptions.inputSourceMap.file = baseName;
-    }
-    if (settings.compilerOptions.sourceMap) {
-      babelOptions.sourceMaps = true;
-    }
-    if (settings.compilerOptions.inlineSourceMap) {
-      babelOptions.sourceMaps = "inline";
-    }
-    if (!settings.compilerOptions.removeComments) {
-      babelOptions.comments = true;
-    }
-
-    let babelResult = babel.transform(outputFile.text, babelOptions);
-    outputFile.text = babelResult.code;
-
-    if (babelResult.map && settings.compilerOptions.sourceMap) {
-      let additionalEmit : ts.OutputFile = {
-        name: sourceMapFileName,
-        text : JSON.stringify(babelResult.map),
-        writeByteOrderMark: settings.compilerOptions.emitBOM
-      };
-
-      if (additionalEmit.name === "") {
-        // can't emit a blank file name - this should only be reached if the TypeScript
-        // language service returns the .js file before the .js.map file.
-        console.warn(`The TypeScript language service did not yet provide a .js.map name for file ${outputFile.name}`);
-        return [];
-      }
-
-      return [additionalEmit];
-    }
-
-    return [];
-  }
-
-  function getJSMapNameForJSFile(jsFileName: string) {
-    for (let jsMapName in sourceMapContents) {
-      if (sourceMapContents.hasOwnProperty(jsMapName)) {
-        if (sourceMapContents[jsMapName].jsFileName === jsFileName) {
-          return jsMapName;
+        if (!isJSFile(outputFile.name) && !isJSSourceMapFile(outputFile.name)) {
+            return [];
         }
-      }
+
+        let settings = project.projectFile.project;
+        let externalTranspiler = settings.externalTranspiler;
+        if (!externalTranspiler) {
+            return [];
+        }
+
+        if (isJSSourceMapFile(outputFile.name)) {
+            let sourceMapPayload = JSON.parse(outputFile.text);
+            let jsFileName = consistentPath(path.resolve(path.dirname(outputFile.name), sourceMapPayload.file));
+            sourceMapContents[outputFile.name] = {jsFileName: jsFileName, sourceMapPayload};
+            return [];
+        }
+
+        if (typeof externalTranspiler === 'string') {
+            externalTranspiler = {
+                name: externalTranspiler as any,
+                options: {}
+            }
+        }
+
+        if (externalTranspiler.name.toLocaleLowerCase() === "babel") {
+            if (!babel) {
+                babel = require("babel")
+            }
+
+            let babelOptions: any = assign({}, externalTranspiler.options, {
+                filename: outputFile.name
+            });
+
+            let sourceMapFileName = getJSMapNameForJSFile(outputFile.name);
+
+            if (sourceMapContents[sourceMapFileName]) {
+                babelOptions.inputSourceMap = sourceMapContents[sourceMapFileName].sourceMapPayload;
+                let baseName = path.basename(sourceFileName);
+                // NOTE: Babel generates invalid source map without consistent `sources` and `file`.
+                babelOptions.inputSourceMap.sources = [baseName];
+                babelOptions.inputSourceMap.file = baseName;
+            }
+            if (settings.compilerOptions.sourceMap) {
+                babelOptions.sourceMaps = true;
+            }
+            if (settings.compilerOptions.inlineSourceMap) {
+                babelOptions.sourceMaps = "inline";
+            }
+            if (!settings.compilerOptions.removeComments) {
+                babelOptions.comments = true;
+            }
+
+            let babelResult = babel.transform(outputFile.text, babelOptions);
+            outputFile.text = babelResult.code;
+
+            if (babelResult.map && settings.compilerOptions.sourceMap) {
+                let additionalEmit : ts.OutputFile = {
+                    name: sourceMapFileName,
+                    text : JSON.stringify(babelResult.map),
+                    writeByteOrderMark: settings.compilerOptions.emitBOM
+                };
+
+                if (additionalEmit.name === "") {
+                    // can't emit a blank file name - this should only be reached if the TypeScript
+                    // language service returns the .js file before the .js.map file.
+                    console.warn(`The TypeScript language service did not yet provide a .js.map name for file ${outputFile.name}`);
+                    return [];
+                }
+
+                return [additionalEmit];
+            }
+
+            return [];
+        }
+
+        function getJSMapNameForJSFile(jsFileName: string) {
+            for (let jsMapName in sourceMapContents) {
+                if (sourceMapContents.hasOwnProperty(jsMapName)) {
+                    if (sourceMapContents[jsMapName].jsFileName === jsFileName) {
+                        return jsMapName;
+                    }
+                }
+            }
+            return "";
+        }
     }
-    return "";
-  }
-}
 
-function isJSFile(fileName: string) {
-  return (path.extname(fileName).toLocaleLowerCase() === ".js");
-}
+    function isJSFile(fileName: string) {
+        return (path.extname(fileName).toLocaleLowerCase() === ".js");
+    }
 
-function isJSSourceMapFile(fileName: string) {
-  let lastExt = path.extname(fileName);
-  if (lastExt === ".map") {
-    return isJSFile(fileName.substr(0,fileName.length - 4));
-  }
-  return false;
-}
+    function isJSSourceMapFile(fileName: string) {
+        let lastExt = path.extname(fileName);
+        if (lastExt === ".map") {
+            return isJSFile(fileName.substr(0,fileName.length - 4));
+        }
+        return false;
+    }

--- a/lib/main/tsconfig/tsconfig.ts
+++ b/lib/main/tsconfig/tsconfig.ts
@@ -116,7 +116,7 @@ interface TypeScriptProjectRawSpecification {
     formatCodeOptions?: formatting.FormatCodeOptions;   // optional: formatting options
     compileOnSave?: boolean;                            // optional: compile on save. Ignored to build tools. Used by IDEs
     buildOnSave?: boolean;
-    externalTranspiler?: string;
+    externalTranspiler?: { name: string; options?: any };
     scripts?: { postbuild?: string };
 }
 
@@ -133,7 +133,7 @@ export interface TypeScriptProjectSpecification {
     compileOnSave: boolean;
     buildOnSave: boolean;
     package?: UsefulFromPackageJson;
-    externalTranspiler?: string;
+    externalTranspiler?: { name: string; options?: any };
     scripts: { postbuild?: string };
 }
 

--- a/lib/main/tsconfig/tsconfig.ts
+++ b/lib/main/tsconfig/tsconfig.ts
@@ -116,7 +116,7 @@ interface TypeScriptProjectRawSpecification {
     formatCodeOptions?: formatting.FormatCodeOptions;   // optional: formatting options
     compileOnSave?: boolean;                            // optional: compile on save. Ignored to build tools. Used by IDEs
     buildOnSave?: boolean;
-    externalTranspiler?: { name: string; options?: any };
+    externalTranspiler?: string | { name: string; options?: any };
     scripts?: { postbuild?: string };
 }
 
@@ -133,7 +133,7 @@ export interface TypeScriptProjectSpecification {
     compileOnSave: boolean;
     buildOnSave: boolean;
     package?: UsefulFromPackageJson;
-    externalTranspiler?: { name: string; options?: any };
+    externalTranspiler?: string | { name: string; options?: any };
     scripts: { postbuild?: string };
 }
 


### PR DESCRIPTION
Hello. I am developing https://github.com/s-panferov/awesome-typescript-loader and I decided to implement a feature to pick-up precompiled files for `.ts` modules if any. I need this to speed-up TypeScript + Babel use-case, because this pair is really slow on a big codebases. Unfortunately, `atom-typescript` `externalTranspiler` functionality has several issues:

1. There is no way to pass options into Babel.
2. There is no way  to use `.babelrc` file, because `filename` property is not passed into babel options and babel doesn't know where to look for the `.babelrc` file.
3. Generated source maps are possibly incorrect, because I get an error while using them in my workflow: 

```
RROR in ../arui/src/icon/common/icon.tsx
Module build failed: Error: No element indexed by 1
    at ArraySet_at [as at] (/Users/panferov-s/Workspace/arui-nyc/node_modules/react-hot-loader/node_modules/source-map/lib/source-map/array-set.js:83:11)
    at SourceMapConsumer_parseMappings [as _parseMappings] (/Users/panferov-s/Workspace/arui-nyc/node_modules/react-hot-loader/node_modules/source-map/lib/source-map/source-map-consumer.js:225:44)
    at SourceMapConsumer.Object.defineProperty.get (/Users/panferov-s/Workspace/arui-nyc/node_modules/react-hot-loader/node_modules/source-map/lib/source-map/source-map-consumer.js:160:14)
    at SourceMapConsumer_eachMapping [as eachMapping] (/Users/panferov-s/Workspace/arui-nyc/node_modules/react-hot-loader/node_modules/source-map/lib/source-map/source-map-consumer.js:455:24)
    at Function.SourceNode_fromStringWithSourceMap (/Users/panferov-s/Workspace/arui-nyc/node_modules/react-hot-loader/node_modules/source-map/lib/source-map/source-node.js:78:26)
    at Object.module.exports (/Users/panferov-s/Workspace/arui-nyc/node_modules/react-hot-loader/index.js:87:16)
 @ ../arui-nyc/src/icon/icon.ts 20:29-65
``` 

I've fixed all the stuff in this PR. All useful changes are in the [first](https://github.com/s-panferov/atom-typescript/commit/2cea69133a0762cddb70d437a423d2a61f770df2) commit. Please take a look.

Related issues:

https://github.com/TypeStrong/atom-typescript/issues/521 Implemented
https://github.com/TypeStrong/atom-typescript/issues/522 Hacked locally by adding `typescript.d.ts` into `tsconfig.json` by hand, but I think that it is not a good solution, so I don't include compiled files into this PR.
