### PR TITLE
Fix Quick Fix overlay issue when toggled on a second file

### DIFF
--- a/dist/main/atom/views/simpleOverlaySelectionView.js
+++ b/dist/main/atom/views/simpleOverlaySelectionView.js
@@ -13,6 +13,7 @@ function default_1(options, editor) {
         singleton = new SimpleOverlaySelectListView(options, editor);
     else {
         singleton.options = options;
+        singleton.editor = editor;
     }
     singleton.setItems();
     singleton.show();

--- a/lib/main/atom/views/simpleOverlaySelectionView.ts
+++ b/lib/main/atom/views/simpleOverlaySelectionView.ts
@@ -17,7 +17,10 @@ var singleton: SimpleOverlaySelectListView<any>;
 
 export default function <T>(options: SelectListViewOptions<T>, editor: AtomCore.IEditor): SimpleOverlaySelectListView<T> {
     if (!singleton) singleton = new SimpleOverlaySelectListView<T>(options, editor);
-    else { singleton.options = options; }
+    else {
+        singleton.options = options;
+        singleton.editor = editor;
+    }
 
     singleton.setItems();
     singleton.show();


### PR DESCRIPTION
This fixes the issue mentioned in https://github.com/TypeStrong/atom-typescript/issues/542. When the SimpleOverlaySelectListView is called after the first initialization, only the options are set on the singleton but not the editor. This leads to the overlay opening in the previous editor when triggered from a second editor. 

This is simply fixed by setting the editor, too, when the singleton already exists. I tested this out for a while and seems to work fine.