### PR TITLE
Use atom-package-deps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,21 +97,6 @@ Advantage: you only need to define the query/response interface once (in `projec
 ## Language Service Documentation
 The TypeScript Language service docs: https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API
 
-## Depending upon other atom packages
-There isn't a documented way : https://discuss.atom.io/t/depending-on-other-packages/2360/16
-
-So using https://www.npmjs.com/package/atom-package-dependencies
-
-```js
-var apd = require('atom-package-dependencies');
-
-var mdp = apd.require('markdown-preview');
-mdp.toggle();
-
-// Also
-apd.install();
-```
-
 ## Showing errors in atom
 Done using the `linter` plugin. If you think about it. TypeScript is really just a super powerful version of `jshint` and that is the reason to use `linter` for errors.
 

--- a/lib/main/atom/commands/commands.ts
+++ b/lib/main/atom/commands/commands.ts
@@ -509,7 +509,7 @@ export function registerCommands() {
     });
     /// Register autocomplete commands to show documentations
     /*atom.packages.activatePackage('autocomplete-plus').then(() => {
-        var autocompletePlus = apd.require('autocomplete-plus'); // Note: apd isn't required here
+        var autocompletePlus = apd.require('autocomplete-plus');
         var maxIndex = 10;
         var currentSuggestionIndex = 0;
         autocompletePlus.autocompleteManager.suggestionList.emitter.on('did-cancel',() => {

--- a/lib/main/atom/commands/commands.ts
+++ b/lib/main/atom/commands/commands.ts
@@ -5,7 +5,6 @@ import autoCompleteProvider = require("../autoCompleteProvider");
 import path = require('path');
 import documentationView = require("../views/documentationView");
 import renameView = require("../views/renameView");
-var apd = require('atom-package-dependencies');
 import contextView = require("../views/contextView");
 import fileSymbolsView = require("../views/fileSymbolsView");
 import projectSymbolsView = require("../views/projectSymbolsView");
@@ -510,7 +509,7 @@ export function registerCommands() {
     });
     /// Register autocomplete commands to show documentations
     /*atom.packages.activatePackage('autocomplete-plus').then(() => {
-        var autocompletePlus = apd.require('autocomplete-plus');
+        var autocompletePlus = apd.require('autocomplete-plus'); // Note: apd isn't required here
         var maxIndex = 10;
         var currentSuggestionIndex = 0;
         autocompletePlus.autocompleteManager.suggestionList.emitter.on('did-cancel',() => {

--- a/lib/main/atomts.ts
+++ b/lib/main/atomts.ts
@@ -6,9 +6,6 @@ import path = require('path');
 import fs = require('fs');
 import os = require('os');
 
-// Make sure we have the packages we depend upon
-var apd = require('atom-package-dependencies');
-
 import {errorView} from "./atom/views/mainPanelView";
 
 ///ts:import=autoCompleteProvider
@@ -285,35 +282,7 @@ function readyToActivate() {
 }
 
 export function activate(state: PackageState) {
-
-    // Don't activate if we have a dependency that isn't available
-    var linter = apd.require('linter');
-    var acp = apd.require('autocomplete-plus');
-
-    if (!linter || !acp) {
-        var notification = atom.notifications.addInfo('AtomTS: Some dependencies not found. Running "apm install" on these for you. Please wait for a success confirmation!', { dismissable: true });
-        apd.install(function() {
-            atom.notifications.addSuccess("AtomTS: Dependencies installed correctly. Enjoy TypeScript \u2665", { dismissable: true });
-            notification.dismiss();
-
-            if (atom.packages.isPackageDisabled('linter')) atom.packages.enablePackage('linter');
-            if (atom.packages.isPackageDisabled('autocomplete-plus')) atom.packages.enablePackage('autocomplete-plus');
-
-            // Packages don't get loaded automatically as a result of an install
-            if (!apd.require('linter')) atom.packages.loadPackage('linter');
-            if (!apd.require('autocomplete-plus')) atom.packages.loadPackage('autocomplete-plus');
-
-            // Hazah activate them and then activate us!
-            atom.packages.activatePackage('linter')
-                .then(() => atom.packages.activatePackage('autocomplete-plus'))
-                .then(() => waitForGrammarActivation())
-                .then(() => readyToActivate());
-        });
-
-        return;
-    }
-
-    waitForGrammarActivation().then(() => readyToActivate());
+    require('atom-package-deps').install('atom-typescript').then(waitForGrammarActivation).then(readyToActivate)
 }
 
 export function deactivate() {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "url": "https://github.com/TypeStrong/atom-typescript/issues"
   },
   "dependencies": {
-    "atom-package-dependencies": "https://github.com/basarat/atom-package-dependencies/archive/cb2.tar.gz",
+    "atom-package-deps": "^2.0.2",
     "atom-space-pen-views": "^2.0.4",
     "babel": "^5.6.23",
     "basarat-text-buffer": "6.0.0",
@@ -62,9 +62,7 @@
     "grunt": "^0.4.5",
     "grunt-ts": "^3.0.0"
   },
-  "package-dependencies": {
-    "linter": "//this field will be ignored right now"
-  },
+  "package-deps": ["linter"],
   "keywords": [
     "typescript",
     "javascript",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "url": "https://github.com/TypeStrong/atom-typescript/issues"
   },
   "dependencies": {
-    "atom-package-deps": "^2.0.2",
+    "atom-package-deps": "^2.0.3",
     "atom-space-pen-views": "^2.0.4",
     "babel": "^5.6.23",
     "basarat-text-buffer": "6.0.0",


### PR DESCRIPTION
It has a method `install` that handles the notification and all for you. It resolves the promise when all deps are installed and enabled/activated.

Some of the linter providers are using it already, others will do it very soon.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/typestrong/atom-typescript/559)
<!-- Reviewable:end -->
