### PR TITLE
Conserves padding during autocomple in JSX

### DIFF
--- a/dist/main/atom/autoCompleteProvider.js
+++ b/dist/main/atom/autoCompleteProvider.js
@@ -51,7 +51,7 @@ exports.provider = {
                     var suggestionText = relativePath;
                     var suggestion = {
                         text: suggestionText,
-                        replacementPrefix: resp.endsInPunctuation ? '' : options.prefix,
+                        replacementPrefix: resp.endsInPunctuation ? '' : options.prefix.trim(),
                         rightLabelHTML: '<span>' + file.name + '</span>',
                         type: 'path'
                     };
@@ -107,7 +107,7 @@ exports.provider = {
                         }
                         return {
                             text: c.name,
-                            replacementPrefix: resp.endsInPunctuation ? '' : prefix,
+                            replacementPrefix: resp.endsInPunctuation ? '' : prefix.trim(),
                             rightLabel: c.display,
                             leftLabel: c.kind,
                             type: atomUtils.kindToType(c.kind),

--- a/lib/main/atom/autoCompleteProvider.ts
+++ b/lib/main/atom/autoCompleteProvider.ts
@@ -141,7 +141,7 @@ export var provider: autocompleteplus.Provider = {
 
                     var suggestion: autocompleteplus.Suggestion = {
                         text: suggestionText,
-                        replacementPrefix: resp.endsInPunctuation ? '' : options.prefix,
+                        replacementPrefix: resp.endsInPunctuation ? '' : options.prefix.trim(),
                         rightLabelHTML: '<span>' + file.name + '</span>',
                         type: 'path'
                     };
@@ -215,7 +215,7 @@ export var provider: autocompleteplus.Provider = {
 
                             return {
                                 text: c.name,
-                                replacementPrefix: resp.endsInPunctuation ? '' : prefix,
+                                replacementPrefix: resp.endsInPunctuation ? '' : prefix.trim(),
                                 rightLabel: c.display,
                                 leftLabel: c.kind,
                                 type: atomUtils.kindToType(c.kind),


### PR DESCRIPTION
By trimming the replacement prefix before handing it back to autocomplete-plus the whitespace in the user code is preserved when activating a suggestion.

Fixes #525 