### PR TITLE
Fixed bad format for some themes & status now easier to read

### DIFF
--- a/dist/main/atom/views/mainPanelView.js
+++ b/dist/main/atom/views/mainPanelView.js
@@ -73,7 +73,7 @@ var MainPanelView = (function (_super) {
                     });
                 });
                 _this.div({
-                    style: 'display:inline-block'
+                    style: 'display:inline-block;overflow-x:visible;white-space:nowrap;'
                 }, function () {
                     _this.span({
                         style: 'margin-left:10px; transition: color 1s',
@@ -184,11 +184,11 @@ var MainPanelView = (function (_super) {
                 var status_1 = fileStatusCache_1.getFileStatus(filePath);
                 _this.fileStatus.removeClass('icon-x icon-check text-error text-success hidden');
                 if (status_1.emitDiffers || status_1.modified) {
-                    _this.fileStatus.text('Js emit is outdated');
+                    _this.fileStatus.text('JS Outdated');
                     _this.fileStatus.addClass('icon-x text-error');
                 }
                 else {
-                    _this.fileStatus.text('Js emit up to date');
+                    _this.fileStatus.text('JS Current');
                     _this.fileStatus.addClass('icon-check text-success');
                 }
             }

--- a/lib/main/atom/views/mainPanelView.ts
+++ b/lib/main/atom/views/mainPanelView.ts
@@ -88,7 +88,7 @@ export class MainPanelView extends view.View<any> {
                         });
 
                         this.div({
-                            style: 'display:inline-block'
+                            style: 'display:inline-block;overflow-x:visible;white-space:nowrap;'
                         }, () => {
                             this.span({
                                 style: 'margin-left:10px; transition: color 1s', // Added transition to make it easy to see *yes I just did this compile*.
@@ -212,10 +212,10 @@ export class MainPanelView extends view.View<any> {
                 let status = getFileStatus(filePath);
                 this.fileStatus.removeClass('icon-x icon-check text-error text-success hidden');
                 if (status.emitDiffers || status.modified) {
-                    this.fileStatus.text('Js emit is outdated');
+                    this.fileStatus.text('JS Outdated');
                     this.fileStatus.addClass('icon-x text-error');
                 } else {
-                    this.fileStatus.text('Js emit up to date');
+                    this.fileStatus.text('JS Current');
                     this.fileStatus.addClass('icon-check text-success');
                 }
             }


### PR DESCRIPTION
Status bar will corrupt/wrap with some themes and zoom levels, this fixes that
JS compilation text is more consistent with the other status text and easier to read as it is shorter