### PR TITLE
Tidy up the CSS for the bottom panel

### DIFF
--- a/dist/main/atom/views/mainPanelView.js
+++ b/dist/main/atom/views/mainPanelView.js
@@ -29,23 +29,19 @@ var MainPanelView = (function (_super) {
         var btn = function (view, text, className) {
             if (className === void 0) { className = ''; }
             return _this.button({
-                'class': "btn " + className,
+                'class': "btn btn-sm " + className,
                 'click': view + "PanelSelectedClick",
-                'outlet': view + "PanelBtn",
-                'style': 'top:-2px!important'
+                'outlet': view + "PanelBtn"
             }, text);
         };
         this.div({
-            class: 'atomts atomts-main-panel-view native-key-bindings layout horizontal',
+            class: 'atomts atomts-main-panel-view native-key-bindings',
+            style: 'padding: 6px',
             tabindex: '-1'
         }, function () {
             _this.div({
-                class: 'panel-resize-handle',
-                style: 'position: absolute; top: 0; left: 0; right: 0; height: 10px; cursor: row-resize; z-index: 3; -webkit-user-select:none'
-            });
-            _this.div({
-                class: 'panel-heading layout horizontal',
-                style: '-webkit-user-select:none',
+                class: 'layout horizontal',
+                style: '-webkit-user-select: none; align-items: center',
                 dblclick: 'toggle'
             }, function () {
                 _this.span({
@@ -57,23 +53,23 @@ var MainPanelView = (function (_super) {
                 });
                 _this.div({
                     class: 'btn-group',
-                    style: 'margin-left: 5px'
+                    style: 'margin-left: 8px'
                 }, function () {
-                    btn("error", panelHeaders.error, 'selected');
-                    btn("build", panelHeaders.build);
-                    btn("references", panelHeaders.references);
+                    btn('error', panelHeaders.error, 'selected');
+                    btn('build', panelHeaders.build);
+                    btn('references', panelHeaders.references);
                 });
                 _this.div({
-                    style: 'display:inline-block; margin-top: 2px; cursor: pointer;',
+                    style: 'cursor: pointer;',
                     click: 'clickedCurrentTsconfigFilePath'
                 }, function () {
                     _this.span({
-                        style: 'margin-left:10px;',
+                        style: 'margin-left: 10px;',
                         outlet: 'tsconfigInUse'
                     });
                 });
                 _this.div({
-                    style: 'display:inline-block;overflow-x:visible;white-space:nowrap;'
+                    style: 'overflow-x: visible; white-space: nowrap;'
                 }, function () {
                     _this.span({
                         style: 'margin-left:10px; transition: color 1s',
@@ -82,28 +78,30 @@ var MainPanelView = (function (_super) {
                 });
                 _this.div({
                     class: 'heading-summary flex',
-                    style: 'display:inline-block; margin-left:5px; margin-top:3px; overflow: hidden; white-space:nowrap; text-overflow: ellipsis',
+                    style: 'margin-left: 5px; overflow: hidden; white-space:nowrap; text-overflow: ellipsis',
                     outlet: 'summary'
                 });
                 _this.progress({
                     class: 'inline-block build-progress',
-                    style: 'display: none; color:red',
+                    style: 'display: none; color: red',
                     outlet: 'buildProgress'
                 });
-                _this.span({ class: 'section-pending', outlet: 'sectionPending' }, function () {
+                _this.span({
+                    class: 'section-pending',
+                    outlet: 'sectionPending',
+                    click: 'showPending'
+                }, function () {
                     _this.span({
                         outlet: 'txtPendingCount',
                         style: 'cursor: pointer; margin-right: 7px;',
                     });
                     _this.span({
                         class: 'loading loading-spinner-tiny inline-block',
-                        style: 'cursor: pointer; margin-right: 7px;',
-                        click: 'showPending'
+                        style: 'cursor: pointer; margin-right: 7px;'
                     });
                 });
                 _this.div({
-                    class: 'heading-buttons',
-                    style: 'width:50px; display:inline-block'
+                    class: 'heading-buttons'
                 }, function () {
                     _this.span({
                         class: 'heading-fold icon-unfold',
@@ -122,17 +120,17 @@ var MainPanelView = (function (_super) {
             _this.div({
                 class: 'panel-body atomts-panel-body padded',
                 outlet: 'errorBody',
-                style: 'overflow-y: auto; display:none'
+                style: 'overflow-y: auto; display: none'
             });
             _this.div({
                 class: 'panel-body atomts-panel-body padded',
                 outlet: 'buildBody',
-                style: 'overflow-y: auto; display:none'
+                style: 'overflow-y: auto; display: none'
             });
             _this.div({
                 class: 'panel-body atomts-panel-body padded',
                 outlet: 'referencesBody',
-                style: 'overflow-y: auto; display:none'
+                style: 'overflow-y: auto; display: none'
             });
         });
     };

--- a/lib/main/atom/views/mainPanelView.ts
+++ b/lib/main/atom/views/mainPanelView.ts
@@ -40,23 +40,19 @@ export class MainPanelView extends view.View<any> {
     static content() {
         var btn = (view, text, className: string = '') =>
             this.button({
-                'class': "btn " + className,
+                'class': `btn btn-sm ${className}`,
                 'click': `${view}PanelSelectedClick`,
-                'outlet': `${view}PanelBtn`,
-                'style': 'top:-2px!important'
+                'outlet': `${view}PanelBtn`
             }, text);
 
         this.div({
-            class: 'atomts atomts-main-panel-view native-key-bindings layout horizontal',
+            class: 'atomts atomts-main-panel-view native-key-bindings',
+            style: 'padding: 6px',
             tabindex: '-1'
         }, () => {
                 this.div({
-                    class: 'panel-resize-handle',
-                    style: 'position: absolute; top: 0; left: 0; right: 0; height: 10px; cursor: row-resize; z-index: 3; -webkit-user-select:none'
-                });
-                this.div({
-                    class: 'panel-heading layout horizontal',
-                    style: '-webkit-user-select:none',
+                    class: 'layout horizontal',
+                    style: '-webkit-user-select: none; align-items: center',
                     dblclick: 'toggle'
                 }, () => {
                         this.span({
@@ -69,26 +65,26 @@ export class MainPanelView extends view.View<any> {
 
                         this.div({
                             class: 'btn-group',
-                            style: 'margin-left: 5px'
+                            style: 'margin-left: 8px'
                         },
                             () => {
-                                btn("error", panelHeaders.error, 'selected')
-                                btn("build", panelHeaders.build)
-                                btn("references", panelHeaders.references)
+                                btn('error', panelHeaders.error, 'selected')
+                                btn('build', panelHeaders.build)
+                                btn('references', panelHeaders.references)
                             });
 
                         this.div({
-                            style: 'display:inline-block; margin-top: 2px; cursor: pointer;',
+                            style: 'cursor: pointer;',
                             click: 'clickedCurrentTsconfigFilePath'
                         }, () => {
                             this.span({
-                                style: 'margin-left:10px;',
+                                style: 'margin-left: 10px;',
                                 outlet: 'tsconfigInUse'
                             });
                         });
 
                         this.div({
-                            style: 'display:inline-block;overflow-x:visible;white-space:nowrap;'
+                            style: 'overflow-x: visible; white-space: nowrap;'
                         }, () => {
                             this.span({
                                 style: 'margin-left:10px; transition: color 1s', // Added transition to make it easy to see *yes I just did this compile*.
@@ -98,31 +94,33 @@ export class MainPanelView extends view.View<any> {
 
                         this.div({
                             class: 'heading-summary flex',
-                            style: 'display:inline-block; margin-left:5px; margin-top:3px; overflow: hidden; white-space:nowrap; text-overflow: ellipsis',
+                            style: 'margin-left: 5px; overflow: hidden; white-space:nowrap; text-overflow: ellipsis',
                             outlet: 'summary'
                         });
 
                         this.progress({
                             class: 'inline-block build-progress',
-                            style: 'display: none; color:red',
+                            style: 'display: none; color: red',
                             outlet: 'buildProgress'
                         });
 
-                        this.span({ class: 'section-pending', outlet: 'sectionPending' }, () => {
+                        this.span({
+                            class: 'section-pending',
+                            outlet: 'sectionPending',
+                            click: 'showPending'
+                        }, () => {
                             this.span({
                                 outlet: 'txtPendingCount',
                                 style: 'cursor: pointer; margin-right: 7px;',
                             });
                             this.span({
                                 class: 'loading loading-spinner-tiny inline-block',
-                                style: 'cursor: pointer; margin-right: 7px;',
-                                click: 'showPending'
+                                style: 'cursor: pointer; margin-right: 7px;'
                             });
                         });
 
                         this.div({
-                            class: 'heading-buttons',
-                            style: 'width:50px; display:inline-block'
+                            class: 'heading-buttons'
                         }, () => {
                                 this.span({
                                     class: 'heading-fold icon-unfold',
@@ -141,17 +139,17 @@ export class MainPanelView extends view.View<any> {
                 this.div({
                     class: 'panel-body atomts-panel-body padded',
                     outlet: 'errorBody',
-                    style: 'overflow-y: auto; display:none'
+                    style: 'overflow-y: auto; display: none'
                 });
                 this.div({
                     class: 'panel-body atomts-panel-body padded',
                     outlet: 'buildBody',
-                    style: 'overflow-y: auto; display:none'
+                    style: 'overflow-y: auto; display: none'
                 });
                 this.div({
                     class: 'panel-body atomts-panel-body padded',
                     outlet: 'referencesBody',
-                    style: 'overflow-y: auto; display:none'
+                    style: 'overflow-y: auto; display: none'
                 });
             });
     }


### PR DESCRIPTION
Mostly making use of flex box instead of display hacks, but also made a change for the buttons to overlay the slightly larger panel resize drag area.

![image](https://cloud.githubusercontent.com/assets/1088987/10060104/aa1102a0-6203-11e5-8be9-d3c095f203a0.png)

![image](https://cloud.githubusercontent.com/assets/1088987/10060110/b3cc5f4c-6203-11e5-9084-fef78c3db097.png)

![image](https://cloud.githubusercontent.com/assets/1088987/10060119/c1f45fd4-6203-11e5-938f-f15bab5867a9.png)

![image](https://cloud.githubusercontent.com/assets/1088987/10060125/ce03d84a-6203-11e5-80d9-f6f577db9ecb.png)

![image](https://cloud.githubusercontent.com/assets/1088987/10060145/de3ff7ac-6203-11e5-9e9e-f9cfd1cce8d9.png)

Edit: Moved the `showPending` to the parent element so people can click on the number (oddly, the theme I'm using doesn't even have a loading icon yet).

Closes #606 