### PR TITLE
Add support for exclude in tsconfig.

### DIFF
--- a/dist/main/tsconfig/tsconfig.js
+++ b/dist/main/tsconfig/tsconfig.js
@@ -212,6 +212,9 @@ function getProjectSync(pathOrSrcFile) {
     var cwdPath = path.relative(process.cwd(), path.dirname(projectFile));
     if (!projectSpec.files && !projectSpec.filesGlob) {
         var toExpand = invisibleFilesGlob;
+        if (projectSpec.exclude) {
+            toExpand = toExpand.concat(projectSpec.exclude.map(function (exclude) { return '!' + exclude; }));
+        }
     }
     if (projectSpec.filesGlob) {
         var toExpand = projectSpec.filesGlob;

--- a/lib/main/tsconfig/tsconfig.ts
+++ b/lib/main/tsconfig/tsconfig.ts
@@ -118,6 +118,7 @@ interface UsefulFromPackageJson {
  */
 interface TypeScriptProjectRawSpecification {
     compilerOptions?: CompilerOptions;
+    exclude?: string[];                                 // optional: An array of 'glob / minimatch / RegExp' patterns to specify directories / files to exclude
     files?: string[];                                   // optional: paths to files
     filesGlob?: string[];                               // optional: An array of 'glob / minimatch / RegExp' patterns to specify source files
     formatCodeOptions?: formatting.FormatCodeOptions;   // optional: formatting options
@@ -384,6 +385,9 @@ export function getProjectSync(pathOrSrcFile: string): TypeScriptProjectFileDeta
     var cwdPath = path.relative(process.cwd(), path.dirname(projectFile));
     if (!projectSpec.files && !projectSpec.filesGlob) { // If there is no files and no filesGlob, we create an invisible one.
         var toExpand = invisibleFilesGlob;
+        if(projectSpec.exclude){
+            toExpand = toExpand.concat(projectSpec.exclude.map((exclude) => '!' + exclude));
+        }
     }
     if (projectSpec.filesGlob) { // If there is a files glob we will use that
         var toExpand = projectSpec.filesGlob


### PR DESCRIPTION
Aimed at closing https://github.com/TypeStrong/atom-typescript/issues/377. However, please note that contrary to https://github.com/Microsoft/TypeScript/pull/3188, this support globs. Also, this seems to be too simple... It does solve our usecase (excluding node_modules, same issue as https://github.com/TypeStrong/atom-typescript/issues/332).