### PR TITLE
"Jumpy" Bottom Bar - fadeOut/fadeIn replaced by animate

### DIFF
--- a/dist/main/atom/views/mainPanelView.js
+++ b/dist/main/atom/views/mainPanelView.js
@@ -209,10 +209,10 @@ var MainPanelView = (function (_super) {
         this.txtPendingCount.html("<span class=\"text-highlight\">" + this.pendingRequests.length + "</span>");
         this.sectionPending.stop();
         if (pending.length) {
-            this.sectionPending.fadeIn(500);
+            this.sectionPending.animate({ opacity: 0.5 }, 500);
         }
         else {
-            this.sectionPending.fadeOut(200);
+            this.sectionPending.animate({ opacity: 0 }, 200);
         }
     };
     MainPanelView.prototype.errorPanelSelectedClick = function () {

--- a/lib/main/atom/views/mainPanelView.ts
+++ b/lib/main/atom/views/mainPanelView.ts
@@ -241,10 +241,10 @@ export class MainPanelView extends view.View<any> {
 
         this.sectionPending.stop();
         if (pending.length) {
-            this.sectionPending.fadeIn(500);
+            this.sectionPending.animate({opacity: 0.5}, 500);
         }
         else {
-            this.sectionPending.fadeOut(200);
+            this.sectionPending.animate({opacity: 0}, 200);
         }
     }
 


### PR DESCRIPTION
By removing the fadeOut we also remove the css rule ```display: none;```. This way the bottom bar doesn't jump on a specific width.