### PR TITLE
workerLib's spawn should preserve the environment

### DIFF
--- a/lib/worker/lib/workerLib.ts
+++ b/lib/worker/lib/workerLib.ts
@@ -231,10 +231,16 @@ export class Parent extends RequesterResponder {
     /** start worker */
     startWorker(childJsPath: string, terminalError: (e: Error) => any, customArguments: string[]) {
         try {
+            var spawnEnv = process.env;
+            spawnEnv['ATOM_SHELL_INTERNAL_RUN_AS_NODE'] = '1';
             this.child = spawn(this.node, [
             // '--debug', // Uncomment if you want to debug the child process
                 childJsPath
-            ].concat(customArguments), { cwd: path.dirname(childJsPath), env: { ATOM_SHELL_INTERNAL_RUN_AS_NODE: '1' }, stdio: ['ipc'] });
+            ].concat(customArguments), {
+              cwd: path.dirname(childJsPath),
+              env: spawnEnv,
+              stdio: ['ipc']
+            });
 
             this.child.on('error', (err) => {
                 if (err.code === "ENOENT" && err.path === this.node) {

--- a/lib/worker/lib/workerLib.ts
+++ b/lib/worker/lib/workerLib.ts
@@ -231,7 +231,10 @@ export class Parent extends RequesterResponder {
     /** start worker */
     startWorker(childJsPath: string, terminalError: (e: Error) => any, customArguments: string[]) {
         try {
-            var spawnEnv = process.env;
+            /** At least on NixOS, the environment must be preserved for
+                dynamic libraries to be properly linked.
+                On Windows/MacOS, it needs to be cleared, cf. atom/atom#2887 */
+            var spawnEnv = (process.platform === 'linux') ? Object.create(process.env) : {};
             spawnEnv['ATOM_SHELL_INTERNAL_RUN_AS_NODE'] = '1';
             this.child = spawn(this.node, [
             // '--debug', // Uncomment if you want to debug the child process


### PR DESCRIPTION
Hello,

Working on NixOS, it is extremely bad that atom-typescript overwrites the environment of the process when calling spawn.
In particular, the child process fails to spawn as it cannot find libgtk-x11.

This patch attempts to solve this issue by only overriding the existing environment.

What is the policy with regards to pull requests? I notice the dist/ repository is tracked, which is weird, but I guess it's useful for bootstrapping?

Best regards,