### PR TITLE
Fixes issue with getScrollTop and getScrollLeft in Atom 1.1.0

### DIFF
--- a/dist/main/atom/tooltipManager.js
+++ b/dist/main/atom/tooltipManager.js
@@ -46,8 +46,8 @@ function attach(editorView, editor) {
         if (exprTypeTooltip)
             return;
         var pixelPt = pixelPositionFromMouseEvent(editorView, e);
-        pixelPt.top += editor.displayBuffer.getScrollTop();
-        pixelPt.left += editor.displayBuffer.getScrollLeft();
+        pixelPt.top += editor.getScrollTop();
+        pixelPt.left += editor.getScrollLeft();
         var screenPt = editor.screenPositionForPixelPosition(pixelPt);
         var bufferPt = editor.bufferPositionForScreenPosition(screenPt);
         var curCharPixelPt = rawView.pixelPositionForBufferPosition([bufferPt.row, bufferPt.column]);


### PR DESCRIPTION
Issue #647 mentions the problem.