### PR TITLE
Support rewriteTsconfig flag in tsconfig.json

### DIFF
--- a/dist/main/tsconfig/tsconfig.js
+++ b/dist/main/tsconfig/tsconfig.js
@@ -174,7 +174,8 @@ function getDefaultInMemoryProject(srcFile) {
         formatCodeOptions: formatting.defaultFormatCodeOptions(),
         compileOnSave: true,
         buildOnSave: false,
-        scripts: {}
+        scripts: {},
+        atom: { rewriteTsconfig: true },
     };
     return {
         projectFileDirectory: dir,
@@ -210,7 +211,7 @@ function getProjectSync(pathOrSrcFile) {
     }
     if (projectSpec.filesGlob) {
         var prettyJSONProjectSpec = prettyJSON(projectSpec, detectIndent(projectFileTextContent).indent);
-        if (prettyJSONProjectSpec !== projectFileTextContent) {
+        if (prettyJSONProjectSpec !== projectFileTextContent && projectSpec.atom.rewriteTsconfig) {
             fs.writeFileSync(projectFile, prettyJSONProjectSpec);
         }
     }
@@ -240,7 +241,8 @@ function getProjectSync(pathOrSrcFile) {
         typings: [],
         externalTranspiler: projectSpec.externalTranspiler == undefined ? undefined : projectSpec.externalTranspiler,
         scripts: projectSpec.scripts || {},
-        buildOnSave: !!projectSpec.buildOnSave
+        buildOnSave: !!projectSpec.buildOnSave,
+        atom: { rewriteTsconfig: true }
     };
     var validationResult = validator.validate(projectSpec.compilerOptions);
     if (validationResult.errorMessage) {

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -3,6 +3,10 @@
 ## I keep getting changes to tsconfig.json
 This is probably because of us keeping `files` updated with the `filesGlob` option. The reason why we do this is because the official `tsconfig.json` spec does not support `filesGlob`. Therefore we keep `files` in sync with the `filesGlob` so that your team mates can use whatever editor they prefer (sublime text, visual studio etc.).
 
+You can now disable this behavior by setting the `rewriteTsconfig` flag to `false` in your project's `tsconfig.json` under the `atom` key.
+
+[Further Details](https://github.com/TypeStrong/atom-typescript/blob/master/docs/tsconfig.md#atom)
+
 ## For really large projects atom-typescript gets slow
 If you have `tsconfig.json` in a folder that contains `node_modules`, atom-typescript might become slow (due to extensive file listing). Two possible fixes:
 * Move `tsconfig.json` into a sub folder e.g. `src`

--- a/docs/tsconfig.md
+++ b/docs/tsconfig.md
@@ -20,6 +20,8 @@ i.e. an empty JSON file at the *root* of your project :heart: This will be suffi
 * [`compileOnSave`](https://github.com/TypeStrong/atom-typescript/blob/master/docs/tsconfig.md#compileonsave) : Should AtomTS compile on save
 * [`buildOnSave`](https://github.com/TypeStrong/atom-typescript/blob/master/docs/tsconfig.md#buildonsave) : Should AtomTS build on save
 * [`scripts`](https://github.com/TypeStrong/atom-typescript/blob/master/docs/tsconfig.md#scripts) : Sometimes its useful to have post build scripts
+* [`atom`](https://github.com/TypeStrong/atom-typescript/blob/master/docs/tsconfig.md#rewriteTsconfig) : Configuration specific to Atom. Currently
+only contains `rewriteTsconfig` which prevents Atom from rewriting a project's `tsconfig.json`.
 
 
 ## Examples
@@ -112,6 +114,24 @@ Build means *compile all files*. Useful if for some reason you are using `--out`
 ```json
 {
   "buildOnSave": true
+}
+```
+
+### atom
+Configuration options specific to Atom.
+
+
+**rewriteTsconfig**
+
+Atom-Typescript constantly resolves the `filesGlob` listed in your `tsconfig.json` to ensure that the glob is in sync
+with your project. If your project doesn't require this (you are managing your `filesGlob` some other way), set this
+to `false` (this defaults to `true`).
+
+```json
+{
+  "atom": {
+    "rewriteTsconfig": true
+  }
 }
 ```
 

--- a/lib/main/tsconfig/tsconfig.ts
+++ b/lib/main/tsconfig/tsconfig.ts
@@ -129,6 +129,7 @@ interface TypeScriptProjectRawSpecification {
     buildOnSave?: boolean;
     externalTranspiler?: string | { name: string; options?: any };
     scripts?: { postbuild?: string };
+    atom?: { rewriteTsconfig?: boolean };
 }
 
 /**
@@ -146,6 +147,7 @@ export interface TypeScriptProjectSpecification {
     package?: UsefulFromPackageJson;
     externalTranspiler?: string | { name: string; options?: any };
     scripts: { postbuild?: string };
+    atom: { rewriteTsconfig: boolean };
 }
 
 ///////// FOR USE WITH THE API /////////////
@@ -337,7 +339,8 @@ export function getDefaultInMemoryProject(srcFile: string): TypeScriptProjectFil
         formatCodeOptions: formatting.defaultFormatCodeOptions(),
         compileOnSave: true,
         buildOnSave: false,
-        scripts: {}
+        scripts: {},
+        atom: { rewriteTsconfig: true },
     };
 
     return {
@@ -388,7 +391,7 @@ export function getProjectSync(pathOrSrcFile: string): TypeScriptProjectFileDeta
     if (projectSpec.filesGlob) { // for filesGlob we keep the files in sync
         var prettyJSONProjectSpec = prettyJSON(projectSpec, detectIndent(projectFileTextContent).indent);
 
-        if (prettyJSONProjectSpec !== projectFileTextContent) {
+        if (prettyJSONProjectSpec !== projectFileTextContent && projectSpec.atom.rewriteTsconfig) {
             fs.writeFileSync(projectFile, prettyJSONProjectSpec);
         }
     }
@@ -421,7 +424,8 @@ export function getProjectSync(pathOrSrcFile: string): TypeScriptProjectFileDeta
         typings: [],
         externalTranspiler: projectSpec.externalTranspiler == undefined ? undefined : projectSpec.externalTranspiler,
         scripts: projectSpec.scripts || {},
-        buildOnSave: !!projectSpec.buildOnSave
+        buildOnSave: !!projectSpec.buildOnSave,
+        atom: { rewriteTsconfig: true }
     };
 
     // Validate the raw compiler options before converting them to TS compiler options


### PR DESCRIPTION
The rewriteTsconfig flag enables users to prevent Atom-Typescript
from rewriting their tsconfig.json. The flag defaults to true,
so users who upgrade won't observe any different behavior.

The FAQ and tsconfig docs have been modified to reflect
rewriteTsconfig.

This resolves #703.