### PR TITLE
don't try to read missing .babelrc file

### DIFF
--- a/dist/main/lang/modules/building.js
+++ b/dist/main/lang/modules/building.js
@@ -106,7 +106,7 @@ function getBabelInstance(projectDirectory) {
         return new Promise(function (resolve) {
             findup(projectDirectory, '.babelrc', function (err, dir) {
                 if (err)
-                    resolve(babel);
+                    return resolve(babel);
                 fs.readFile(path.join(dir, '.babelrc'), function (err, data) {
                     try {
                         babelConfigs[projectDirectory] = JSON.parse(data.toString());

--- a/lib/main/lang/modules/building.ts
+++ b/lib/main/lang/modules/building.ts
@@ -131,7 +131,7 @@ function getBabelInstance(projectDirectory: string) {
     }).then(babel => {
         return new Promise<any>(resolve => {
             findup(projectDirectory, '.babelrc', function(err: any, dir) {
-                if (err) resolve(babel);
+                if (err) return resolve(babel);
 
                 fs.readFile(path.join(dir, '.babelrc'), function(err, data) {
                     try {


### PR DESCRIPTION
Conditional to proceed or not after seeking .babelrc was not
couched in else nor returning, and therefore was both resolve(babel)ing as well
as going and trying to read the non-existent file.

Don't try to read the non-existent file.

Closes #742