### PR TITLE
catch `getEmitOutput` errors, cram them into errors list

### DIFF
--- a/dist/main/atom/buildView.js
+++ b/dist/main/atom/buildView.js
@@ -25,8 +25,8 @@ function setBuildOutput(buildOutput) {
             mainPanelView.panelView.addBuild(new lineMessageView.LineMessageView({
                 goToLine: function (filePath, line, col) { return gotoHistory.gotoLine(filePath, line, col, gotoHistory.buildOutput); },
                 message: error.message,
-                line: error.startPos.line + 1,
-                col: error.startPos.col,
+                line: error.startPos ? error.startPos.line + 1 : null,
+                col: error.startPos ? error.startPos.col : null,
                 file: error.filePath,
                 preview: error.preview
             }));

--- a/lib/main/atom/buildView.ts
+++ b/lib/main/atom/buildView.ts
@@ -33,7 +33,7 @@ export function setBuildOutput(buildOutput: BuildOutput) {
     else {
         mainPanelView.panelView.setBuildPanelCount(0);
     }
-    
+
     // Update the errors list for goto history
     gotoHistory.buildOutput.members = [];
 
@@ -45,8 +45,8 @@ export function setBuildOutput(buildOutput: BuildOutput) {
             mainPanelView.panelView.addBuild(new lineMessageView.LineMessageView({
                 goToLine: (filePath, line, col) => gotoHistory.gotoLine(filePath, line, col, gotoHistory.buildOutput),
                 message: error.message,
-                line: error.startPos.line + 1,
-                col: error.startPos.col,
+                line: error.startPos ? error.startPos.line + 1 : null,
+                col: error.startPos ? error.startPos.col : null,
                 file: error.filePath,
                 preview: error.preview
             }));


### PR DESCRIPTION
This patch rather uncleanly handles errors thrown by `getEmitOutput` and pushes them into output.errors.

Two improvements are needed.

1. This isn't a very good solution to unhandled errors in the build. A cleaner and higher-level try/catch might make sense?
2. The underlying problem in my tsconfig.json could stand to be caught specifically and handled in a manner that helps the developer more than waiting for `getEmitOutput` to throw.

Closes #745 