### PR TITLE
use externalTranspiler before doing diffs for status

### DIFF
--- a/dist/main/lang/modules/building.js
+++ b/dist/main/lang/modules/building.js
@@ -78,6 +78,18 @@ function getRawOutput(proj, filePath) {
     return output;
 }
 exports.getRawOutput = getRawOutput;
+function getRawOutputPostExternal(proj, filePath) {
+    var output1 = getRawOutput(proj, filePath);
+    var sourceFile = proj.languageService.getSourceFile(filePath);
+    var sourceMapContents = {};
+    return runExternalTranspiler(filePath, sourceFile.text, output1.outputFiles[0], proj, sourceMapContents).then(function () {
+        return {
+            outputFiles: output1.outputFiles,
+            emitSkipped: false
+        };
+    });
+}
+exports.getRawOutputPostExternal = getRawOutputPostExternal;
 function getBabelInstance(projectDirectory) {
     return new Promise(function (resolve) {
         if (!babels[projectDirectory]) {

--- a/dist/main/lang/projectService.js
+++ b/dist/main/lang/projectService.js
@@ -599,23 +599,27 @@ exports.getOutputJs = getOutputJs;
 function getOutputJsStatus(query) {
     projectCache_1.consistentPath(query);
     var project = projectCache_1.getOrCreateProject(query.filePath);
-    var output = building_1.getRawOutput(project, query.filePath);
-    if (output.emitSkipped) {
-        if (output.outputFiles && output.outputFiles.length === 1) {
-            if (output.outputFiles[0].text === building.Not_In_Context) {
+    return building_1.getRawOutputPostExternal(project, query.filePath)
+        .then(function (output) {
+        if (output.emitSkipped) {
+            if (output.outputFiles && output.outputFiles.length === 1) {
+                if (output.outputFiles[0].text === building.Not_In_Context) {
+                    return resolve({ emitDiffers: false });
+                }
+            }
+            return resolve({ emitDiffers: true });
+        }
+        else {
+            var jsFile = output.outputFiles.filter(function (x) { return path.extname(x.name) == ".js"; })[0];
+            if (!jsFile) {
                 return resolve({ emitDiffers: false });
             }
+            else {
+                var emitDiffers = !fs.existsSync(jsFile.name) || fs.readFileSync(jsFile.name).toString() !== jsFile.text;
+                return resolve({ emitDiffers: emitDiffers });
+            }
         }
-        return resolve({ emitDiffers: true });
-    }
-    var jsFile = output.outputFiles.filter(function (x) { return path.extname(x.name) == ".js"; })[0];
-    if (!jsFile) {
-        return resolve({ emitDiffers: false });
-    }
-    else {
-        var emitDiffers = !fs.existsSync(jsFile.name) || fs.readFileSync(jsFile.name).toString() !== jsFile.text;
-        return resolve({ emitDiffers: emitDiffers });
-    }
+    });
 }
 exports.getOutputJsStatus = getOutputJsStatus;
 function softReset(query) {

--- a/lib/main/lang/modules/building.ts
+++ b/lib/main/lang/modules/building.ts
@@ -106,6 +106,20 @@ export function getRawOutput(proj: project.Project, filePath: string): ts.EmitOu
     return output;
 }
 
+export function getRawOutputPostExternal(proj: project.Project, filePath: string): Promise<ts.EmitOutput> {
+    var output1 = getRawOutput(proj, filePath);
+    let sourceFile = proj.languageService.getSourceFile(filePath);
+    let sourceMapContents: { [index: string]: any } = {};
+    return runExternalTranspiler(
+      filePath, sourceFile.text, output1.outputFiles[0], proj, sourceMapContents
+    ).then(() => {
+      return {
+        outputFiles: output1.outputFiles,
+        emitSkipped: false
+      };
+    });
+}
+
 function getBabelInstance(projectDirectory: string) {
     return new Promise<any>(resolve => {
         if (!babels[projectDirectory]) {

--- a/lib/main/lang/projectService.ts
+++ b/lib/main/lang/projectService.ts
@@ -124,7 +124,7 @@ export function build(query: BuildQuery): Promise<BuildResponse> {
         return output;
     });
 
-    // Also optionally emit a root dts:		
+    // Also optionally emit a root dts:
     building.emitDts(proj);
 
     // If there is a post build script to run ... run it
@@ -138,7 +138,7 @@ export function build(query: BuildQuery): Promise<BuildResponse> {
             }
         });
     }
-    
+
     let tsFilesWithInvalidEmit = outputs
         .filter((o) => o.emitError)
         .map((o) => o.sourceFileName);
@@ -909,7 +909,7 @@ export function applyQuickFix(query: ApplyQuickFixQuery): Promise<ApplyQuickFixR
 interface GetOutputResponse {
     output: ts.EmitOutput;
 }
-import {getRawOutput} from "./modules/building";
+import {getRawOutputPostExternal, getRawOutput} from "./modules/building";
 export function getOutput(query: FilePathQuery): Promise<GetOutputResponse> {
     consistentPath(query);
     var project = getOrCreateProject(query.filePath);
@@ -938,22 +938,26 @@ interface GetOutputJsStatusResponse {
 export function getOutputJsStatus(query: FilePathQuery): Promise<GetOutputJsStatusResponse> {
     consistentPath(query);
     var project = getOrCreateProject(query.filePath);
-    var output = getRawOutput(project, query.filePath);
-    if (output.emitSkipped) {
-        if (output.outputFiles && output.outputFiles.length === 1) {
-            if (output.outputFiles[0].text === building.Not_In_Context) {
+    return getRawOutputPostExternal(project, query.filePath)
+    .then((output) => {
+        if (output.emitSkipped) {
+            if (output.outputFiles && output.outputFiles.length === 1) {
+                if (output.outputFiles[0].text === building.Not_In_Context) {
+                    return resolve({ emitDiffers: false });
+                }
+            }
+            return resolve({ emitDiffers: true });
+        }
+        else {
+            var jsFile = output.outputFiles.filter(x=> path.extname(x.name) == ".js")[0];
+            if (!jsFile) {
                 return resolve({ emitDiffers: false });
+            } else {
+                var emitDiffers = !fs.existsSync(jsFile.name) || fs.readFileSync(jsFile.name).toString() !== jsFile.text;
+                return resolve({ emitDiffers });
             }
         }
-        return resolve({ emitDiffers: true });
-    }
-    var jsFile = output.outputFiles.filter(x=> path.extname(x.name) == ".js")[0];
-    if (!jsFile) {
-        return resolve({ emitDiffers: false });
-    } else {
-        var emitDiffers = !fs.existsSync(jsFile.name) || fs.readFileSync(jsFile.name).toString() !== jsFile.text;
-        return resolve({ emitDiffers });
-    }
+    });
 }
 
 /**


### PR DESCRIPTION
Create new function `getRawOutputRetranspiled` with same interface
as getRawOutput except that it returns a Promise.

This function calls getRawOutut, then passes the result through
`runExternalTranspiler` so that babel, if configured, is applied.

Call/use this new function in `getOutputJsStatus`.

Net result: people using babel are not constantly being told their
JS is Outdated.

Closes #736