### PR TITLE
Adding an external resolver in tsconfig.json

### DIFF
--- a/lib/main/tsconfig/tsconfig.ts
+++ b/lib/main/tsconfig/tsconfig.ts
@@ -138,6 +138,7 @@ interface TypeScriptProjectRawSpecification {
     compileOnSave?: boolean;                            // optional: compile on save. Ignored to build tools. Used by IDEs
     buildOnSave?: boolean;
     externalTranspiler?: string | { name: string; options?: any };
+    externalResolver?: string | { name: string; options?: any };
     scripts?: { postbuild?: string };
     atom?: { rewriteTsconfig?: boolean };
 }
@@ -156,6 +157,7 @@ export interface TypeScriptProjectSpecification {
     buildOnSave: boolean;
     package?: UsefulFromPackageJson;
     externalTranspiler?: string | { name: string; options?: any };
+    externalResolver?: string | { name: string; options? : any };
     scripts: { postbuild?: string };
     atom: { rewriteTsconfig: boolean };
 }
@@ -440,6 +442,7 @@ export function getProjectSync(pathOrSrcFile: string): TypeScriptProjectFileDeta
         package: pkg,
         typings: [],
         externalTranspiler: projectSpec.externalTranspiler == undefined ? undefined : projectSpec.externalTranspiler,
+        externalResolver: projectSpec.externalResolver == undefined ? undefined : projectSpec.externalResolver,
         scripts: projectSpec.scripts || {},
         buildOnSave: !!projectSpec.buildOnSave,
         atom: { rewriteTsconfig: true }


### PR DESCRIPTION
I've added a new property in `tsconfig.json` called `externalResolver`. The property can be either a string or a `{ name : string, options: any }`.

This fixes #776 

The name is a relative path to the folder of the `tsconfig.json` file. The external resolver should be a JavaScript file that exports a constructor of the resolver (see `ResolverConstructor` below).

    export interface ResolvedModule {
        resolvedFileName: string;
        /*
         * Denotes if 'resolvedFileName' is isExternalLibraryImport and thus should be proper external module:
         * - be a .d.ts file
         * - use top level imports\exports
         * - don't use tripleslash references
         */
        isExternalLibraryImport?: boolean;
    }

    interface ResolverInstance {
        resolveModuleNames(moduleNames: string[], containingFile: string): ResolvedModule[];
    };
    
    type ResolverConstructor = new (config: tsconfig.TypeScriptProjectFileDetails, options? : any) => ResolverInstance;


This is an example `tsconfig.json`

    {
        "compilerOptions": {
            "module": "commonjs",
            "noImplicitAny": true,
            "sourceMap": true,
            "target": "ES5"
        },
        "compileOnSave": false,
        "buildOnSave": false,
        "externalResolver": "resolver.js"
    }

And example `resolver.js` file.

    var webpack = require("webpack");
    var path = require("path");
    var fs = require("fs");
    var makeResolver = require("awesome-typescript-loader/dist/resolver");

    function WebPackResolver(config, options) {
    this.options = options || { config: "./webpack.config.js" };
    this.makeResolver();
    }

    WebPackResolver.prototype.makeResolver = function () {
        this.resolver = null;
        if (this.watcher) {
            this.watcher.close();
        }

        var configPath = path.join(__dirname, this.options.config);
        var self = this;
        this.watcher = fs.watch(configPath, { persistent: false, }, function () {  self.makeResolver(); });

        var config;
        try {
            delete require.cache[configPath];
            config = require(configPath);
        } catch (err) {
            console.error(err);
        }

        try {
            this.resolver = makeResolver.default(webpack(config || { }).options);
        } catch (err) {
            console.error(err);
        }
    }

    WebPackResolver.prototype.resolveModuleNames = function (moduleNames, containingFile) {
        var resolver = this.resolver;
        if (!resolver) {
            return [];
        }

        return moduleNames.map(function (moduleName) {
            var resolvedFileName;
            try {
                resolvedFileName = resolver.resolveSync(path.dirname(containingFile), moduleName);
            } catch (err) {
                console.error(err);
                return;
            }
            return { resolvedFileName: resolvedFileName }
        });
    }

    module.exports = WebPackResolver;

