### PR TITLE
Fix tsconfig.md regarding ./ prefix

### DIFF
--- a/docs/tsconfig.md
+++ b/docs/tsconfig.md
@@ -59,7 +59,7 @@ A default `filesGlob` is available for you as a snippet : `fg`
     },
     "filesGlob": [
         "**/*.ts",
-        "!node_modules/**/*.ts"
+        "!node_modules/**"
     ],
     "files": [
         "globals.ts",

--- a/docs/tsconfig.md
+++ b/docs/tsconfig.md
@@ -58,16 +58,16 @@ A default `filesGlob` is available for you as a snippet : `fg`
         "noLib": false
     },
     "filesGlob": [
-        "./**/*.ts",
-        "!./node_modules/**/*.ts"
+        "**/*.ts",
+        "!node_modules/**/*.ts"
     ],
     "files": [
-        "./globals.ts",
-        "./linter.ts",
-        "./main/atom/atomUtils.ts",
-        "./main/atom/autoCompleteProvider.ts",
-        "./worker/messages.ts",
-        "./worker/parent.ts"
+        "globals.ts",
+        "linter.ts",
+        "main/atom/atomUtils.ts",
+        "main/atom/autoCompleteProvider.ts",
+        "worker/messages.ts",
+        "worker/parent.ts"
     ]
 }
 ```

--- a/docs/tsconfig.md
+++ b/docs/tsconfig.md
@@ -59,6 +59,7 @@ A default `filesGlob` is available for you as a snippet : `fg`
     },
     "filesGlob": [
         "**/*.ts",
+        "**/*.tsx",
         "!node_modules/**"
     ],
     "files": [


### PR DESCRIPTION
Here is a little fix for the tsconfig.md documentation.
You mention a 'gs' snippet but the example in tsconfig.md differs from the snippet.
Is does not just differ but it seems to have a bug. I tried it and
the ./ prefix does not work for me - so I removed it for you.
Also the generated files section has no ./ prefix.