### PR TITLE
Support for option "disableCompileOnSave", which is used by atom editor

### DIFF
--- a/lib/main/tsconfig/tsconfig.ts
+++ b/lib/main/tsconfig/tsconfig.ts
@@ -95,6 +95,7 @@ var compilerOptionsValidation: simpleValidator.ValidationInfo = {
     noErrorTruncation: { type: types.boolean },
     noFallthroughCasesInSwitch: { type: types.boolean },
     noImplicitAny: { type: types.boolean },
+    disableCompileOnSave: { type: types.boolean },
     noImplicitReturns: { type: types.boolean },
     noLib: { type: types.boolean },
     noLibCheck: { type: types.boolean },


### PR DESCRIPTION
Atom use "disableCompileOnSave" to prevent single file compilation on save