### PR TITLE
tsconfig.json is saved with the same new line characters as the previous one

### DIFF
--- a/dist/main/tsconfig/tsconfig.js
+++ b/dist/main/tsconfig/tsconfig.js
@@ -71,6 +71,7 @@ var path = require('path');
 var tsconfig = require('tsconfig');
 var os = require('os');
 var detectIndent = require('detect-indent');
+var detectNewline = require('detect-newline');
 var formatting = require('./formatting');
 var projectFileName = 'tsconfig.json';
 var defaultFilesGlob = [
@@ -221,7 +222,7 @@ function getProjectSync(pathOrSrcFile) {
         };
     }
     if (projectSpec.filesGlob) {
-        var prettyJSONProjectSpec = prettyJSON(projectSpec, detectIndent(projectFileTextContent).indent);
+        var prettyJSONProjectSpec = prettyJSON(projectSpec, detectIndent(projectFileTextContent).indent, detectNewline(projectFileTextContent));
         if (prettyJSONProjectSpec !== projectFileTextContent && projectSpec.atom.rewriteTsconfig) {
             fs.writeFileSync(projectFile, prettyJSONProjectSpec);
         }
@@ -427,8 +428,9 @@ function getDefinitionsForNodeModules(projectDir, files) {
         .filter(function (x) { return existing[x]; });
     return { implicit: implicit, ours: ours, packagejson: packagejson };
 }
-function prettyJSON(object, indent) {
+function prettyJSON(object, indent, newLine) {
     if (indent === void 0) { indent = 4; }
+    if (newLine === void 0) { newLine = os.EOL; }
     var cache = [];
     var value = JSON.stringify(object, function (key, value) {
         if (typeof value === 'object' && value !== null) {
@@ -439,7 +441,7 @@ function prettyJSON(object, indent) {
         }
         return value;
     }, indent);
-    value = value.split('\n').join(os.EOL) + os.EOL;
+    value = value.replace(/(?:\r\n|\r|\n)/g, newLine) + newLine;
     cache = null;
     return value;
 }

--- a/lib/globals.ts
+++ b/lib/globals.ts
@@ -39,6 +39,11 @@ declare module 'detect-indent' {
     export = detectIndent;
 }
 
+declare module 'detect-newline' {
+    function detectNewline (string: string): string;
+    export = detectNewline;
+}
+
 declare module 'xtend' {
     function extend <T, U> (dest: T, src: U): T & U;
     export = extend;

--- a/lib/main/tsconfig/tsconfig.ts
+++ b/lib/main/tsconfig/tsconfig.ts
@@ -212,6 +212,7 @@ import path = require('path');
 import tsconfig = require('tsconfig');
 import os = require('os');
 import detectIndent = require('detect-indent');
+import detectNewline = require('detect-newline');
 import extend = require('xtend');
 import formatting = require('./formatting');
 
@@ -406,7 +407,7 @@ export function getProjectSync(pathOrSrcFile: string): TypeScriptProjectFileDeta
     }
 
     if (projectSpec.filesGlob) { // for filesGlob we keep the files in sync
-        var prettyJSONProjectSpec = prettyJSON(projectSpec, detectIndent(projectFileTextContent).indent);
+        var prettyJSONProjectSpec = prettyJSON(projectSpec, detectIndent(projectFileTextContent).indent, detectNewline(projectFileTextContent));
 
         if (prettyJSONProjectSpec !== projectFileTextContent && projectSpec.atom.rewriteTsconfig) {
             fs.writeFileSync(projectFile, prettyJSONProjectSpec);
@@ -703,7 +704,7 @@ function getDefinitionsForNodeModules(projectDir: string, files: string[]): { ou
     return { implicit, ours, packagejson };
 }
 
-export function prettyJSON(object: any, indent: string | number = 4): string {
+export function prettyJSON(object: any, indent: string | number = 4, newLine: string = os.EOL): string {
     var cache = [];
     var value = JSON.stringify(
         object,
@@ -721,7 +722,7 @@ export function prettyJSON(object: any, indent: string | number = 4): string {
         },
         indent
     );
-    value = value.split('\n').join(os.EOL) + os.EOL;
+    value = value.replace(/(?:\r\n|\r|\n)/g, newLine) + newLine;
     cache = null;
     return value;
 }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "basarat-text-buffer": "6.0.0",
     "d3": "^3.5.5",
     "detect-indent": "^4.0.0",
+    "detect-newline": "^2.1.0",
     "emissary": "^1.3.3",
     "escape-html": "^1.0.1",
     "findup": "^0.1.5",


### PR DESCRIPTION
I fixed #678 to be able to save tsconfig.json with LF in Windows.
Used https://github.com/sindresorhus/detect-newline because there are already used detect-indent.