### PR TITLE
Fix String Highlighting

### DIFF
--- a/grammars/ts.cson
+++ b/grammars/ts.cson
@@ -602,7 +602,7 @@ repository:
           "2":
             name: "keyword.other.ts"
           "3":
-            name: "es6import.path.string"
+            name: "es6import.path.quoted.string"
       }
       {
         comment: "Match import = require"
@@ -615,7 +615,7 @@ repository:
           "3":
             name: "keyword.other.ts"
           "4":
-            name: "require.path.string"
+            name: "require.path.quoted.string"
       }
       {
         comment: "Match <amd-module"
@@ -624,7 +624,7 @@ repository:
           "1":
             name: "keyword.other.ts"
           "2":
-            name: "amd.path.string"
+            name: "amd.path.quoted.string"
           "3":
             name: "keyword.other.ts"
       }
@@ -635,7 +635,7 @@ repository:
           "1":
             name: "keyword.other.ts"
           "2":
-            name: "amd.path.string"
+            name: "amd.path.quoted.string"
           "3":
             name: "keyword.other.ts"
       }
@@ -646,7 +646,7 @@ repository:
           "1":
             name: "keyword.other.ts"
           "2":
-            name: "reference.path.string"
+            name: "reference.path.quoted.string"
           "3":
             name: "keyword.other.ts"
       }
@@ -862,7 +862,7 @@ repository:
       }
     ]
   "qstring-double":
-    name: "string.double.ts"
+    name: "string.double.quoted.ts"
     begin: "\""
     end: "\"|(?=$)"
     patterns: [
@@ -871,7 +871,7 @@ repository:
       }
     ]
   "qstring-single":
-    name: "string.single.ts"
+    name: "string.single.quoted.ts"
     begin: "'"
     end: "'|(?=$)"
     patterns: [
@@ -880,7 +880,7 @@ repository:
       }
     ]
   regex:
-    name: "string.regex.ts"
+    name: "string.quoted.regex.ts"
     begin: "(?<=[=(:,\\[]|^|return|&&|\\|\\||!)\\s*(/)(?![/*+{}?])"
     end: "$|(/)[igm]*"
     patterns: [
@@ -894,7 +894,7 @@ repository:
       }
     ]
   string:
-    name: "string.ts"
+    name: "string.quoted.ts"
     patterns: [
       {
         include: "#qstring-single"
@@ -908,11 +908,11 @@ repository:
     begin: "`"
     beginCaptures:
       "0":
-        name: "string.template.ts"
+        name: "string.quoted.template.ts"
     end: "`"
     endCaptures:
       "0":
-        name: "string.template.ts"
+        name: "string.quoted.template.ts"
     patterns: [
       {
         include: "#template-substitution-element"
@@ -922,7 +922,7 @@ repository:
       }
     ]
   "template-string-contents":
-    name: "string.template.ts"
+    name: "string.quoted.template.ts"
     begin: ".*?"
     end: "(?=(\\$\\{|`))"
     patterns: [

--- a/grammars/tsx.cson
+++ b/grammars/tsx.cson
@@ -602,7 +602,7 @@ repository:
           "2":
             name: "keyword.other.ts"
           "3":
-            name: "es6import.path.string"
+            name: "es6import.path.quoted.string"
       }
       {
         comment: "Match import = require"
@@ -615,7 +615,7 @@ repository:
           "3":
             name: "keyword.other.ts"
           "4":
-            name: "require.path.string"
+            name: "require.path.quoted.string"
       }
       {
         comment: "Match <amd-module"
@@ -624,7 +624,7 @@ repository:
           "1":
             name: "keyword.other.ts"
           "2":
-            name: "amd.path.string"
+            name: "amd.path.quoted.string"
           "3":
             name: "keyword.other.ts"
       }
@@ -635,7 +635,7 @@ repository:
           "1":
             name: "keyword.other.ts"
           "2":
-            name: "amd.path.string"
+            name: "amd.path.quoted.string"
           "3":
             name: "keyword.other.ts"
       }
@@ -646,7 +646,7 @@ repository:
           "1":
             name: "keyword.other.ts"
           "2":
-            name: "reference.path.string"
+            name: "reference.path.quoted.string"
           "3":
             name: "keyword.other.ts"
       }
@@ -847,7 +847,7 @@ repository:
       }
     ]
   "qstring-double":
-    name: "string.double.tsx"
+    name: "string.quoted.double.tsx"
     begin: "\""
     end: "\"|(?=$)"
     patterns: [
@@ -856,7 +856,7 @@ repository:
       }
     ]
   "qstring-single":
-    name: "string.single.tsx"
+    name: "string.quoted.single.tsx"
     begin: "'"
     end: "'|(?=$)"
     patterns: [
@@ -865,7 +865,7 @@ repository:
       }
     ]
   regex:
-    name: "string.regex.tsx"
+    name: "string.quoted.regex.tsx"
     begin: "(?<=[=(:,\\[]|^|return|&&|\\|\\||!)\\s*(/)(?![/*+{}?])"
     end: "$|(/)[igm]*"
     patterns: [
@@ -893,11 +893,11 @@ repository:
     begin: "`"
     beginCaptures:
       "0":
-        name: "string.template.tsx"
+        name: "string.quoted.template.tsx"
     end: "`"
     endCaptures:
       "0":
-        name: "string.template.tsx"
+        name: "string.quoted.template.tsx"
     patterns: [
       {
         include: "#template-substitution-element"
@@ -907,7 +907,7 @@ repository:
       }
     ]
   "template-string-contents":
-    name: "string.template.tsx"
+    name: "string.quoted.template.tsx"
     begin: ".*?"
     end: "(?=(\\$\\{|`))"
     patterns: [

--- a/scripts/grammar.js
+++ b/scripts/grammar.js
@@ -22,7 +22,7 @@ var atomPatterns = [
         name: 'keyword.other.ts'
       },
       '2': {
-        name: 'reference.path.string'
+        name: 'reference.path.string.quoted'
       },
       '3': {
         name: 'keyword.other.ts'
@@ -37,7 +37,7 @@ var atomPatterns = [
         name: 'keyword.other.ts'
       },
       '2': {
-        name: 'amd.path.string'
+        name: 'amd.path.string.quoted'
       },
       '3': {
         name: 'keyword.other.ts'
@@ -52,7 +52,7 @@ var atomPatterns = [
         name: 'keyword.other.ts'
       },
       '2': {
-        name: 'amd.path.string'
+        name: 'amd.path.string.quoted'
       },
       '3': {
         name: 'keyword.other.ts'
@@ -73,7 +73,7 @@ var atomPatterns = [
         name: 'keyword.other.ts'
       },
       '4': {
-        name: 'require.path.string'
+        name: 'require.path.string.quoted'
       }
     }
   },
@@ -88,7 +88,7 @@ var atomPatterns = [
         name: 'keyword.other.ts'
       },
       '3': {
-        name: 'es6import.path.string'
+        name: 'es6import.path.string.quoted'
       }
     }
   }
@@ -99,8 +99,23 @@ Promise.all([
   request('https://raw.githubusercontent.com/Microsoft/TypeScript-TmLanguage/master/TypeScriptReact.YAML-tmLanguage')
 ])
   .then(function (result) {
+    var name
     var ts = yaml.safeLoad(result[0].body)
     var tsx = yaml.safeLoad(result[1].body)
+
+    for(var key in ts.repository) {
+      name = ts.repository[key].name
+      if(name && name.indexOf('string.quoted') === -1) {
+        ts.repository[key].name = name.replace('string', 'string.quoted')
+      }
+    }
+
+    for(var key in tsx.repository) {
+      name = tsx.repository[key].name
+      if(name && name.indexOf('string.quoted') === -1) {
+        tsx.repository[key].name = name.replace('string', 'string.quoted')
+      }
+    }
 
     atomPatterns.forEach(function (pattern) {
       ts.repository.expression.patterns.unshift(pattern)


### PR DESCRIPTION
I noticed that strings were no longer being colored correctly.  This may have been due to a recent change where the styles of Atom now include quoted in the name.

I figured this out by comparing the styles between atom-typescript and the other language syntax plugins. 