### PR TITLE
fix #545, respect compiler option `newLine`

### DIFF
--- a/dist/main/lang/core/languageServiceHost2.js
+++ b/dist/main/lang/core/languageServiceHost2.js
@@ -1,6 +1,7 @@
 "use strict";
 var path = require('path');
 var fs = require('fs');
+var os = require('os');
 var textBuffer = require('basarat-text-buffer');
 function createScriptInfo(fileName, text, isOpen) {
     if (isOpen === void 0) { isOpen = false; }
@@ -206,6 +207,18 @@ var LanguageServiceHost = (function () {
             return { preview: preview, position: position };
         };
         this.getCompilationSettings = function () { return _this.config.project.compilerOptions; };
+        this.getNewLine = function () {
+            var eol = os.EOL;
+            switch (_this.config.project.compilerOptions.newLine) {
+                case ts.NewLineKind.CarriageReturnLineFeed:
+                    eol = "\r\n";
+                    break;
+                case ts.NewLineKind.LineFeed:
+                    eol = "\n";
+                    break;
+            }
+            return eol;
+        };
         this.getScriptFileNames = function () { return Object.keys(_this.fileNameToScript); };
         this.getScriptVersion = function (fileName) {
             var script = _this.fileNameToScript[fileName];

--- a/dist/main/tsconfig/tsconfig.js
+++ b/dist/main/tsconfig/tsconfig.js
@@ -140,7 +140,9 @@ function rawToTsCompilerOptions(jsonOptions, projectDir) {
     var compilerOptions = mixin({}, exports.defaults);
     for (var key in jsonOptions) {
         if (typescriptEnumMap[key]) {
-            compilerOptions[key] = typescriptEnumMap[key][jsonOptions[key].toLowerCase()];
+            var name_1 = jsonOptions[key];
+            var map = typescriptEnumMap[key];
+            compilerOptions[key] = map[name_1.toLowerCase()] || map[name_1.toUpperCase()];
         }
         else {
             compilerOptions[key] = jsonOptions[key];

--- a/lib/main/lang/core/languageServiceHost2.ts
+++ b/lib/main/lang/core/languageServiceHost2.ts
@@ -1,6 +1,7 @@
 import path = require('path');
 import utils = require('../utils');
 import fs = require('fs');
+import os = require('os')
 import textBuffer = require('basarat-text-buffer');
 
 import tsconfig = require('../../tsconfig/tsconfig');
@@ -328,6 +329,18 @@ export class LanguageServiceHost implements ts.LanguageServiceHost {
     ////////////////////////////////////////
 
     getCompilationSettings = () => this.config.project.compilerOptions;
+    getNewLine = () => {
+        let eol = os.EOL;
+        switch (this.config.project.compilerOptions.newLine) {
+            case ts.NewLineKind.CarriageReturnLineFeed:
+                eol = "\r\n";
+                break;
+            case ts.NewLineKind.LineFeed:
+                eol = "\n";
+                break;
+        }
+        return eol;
+    }
     getScriptFileNames = (): string[]=> Object.keys(this.fileNameToScript);
     getScriptVersion = (fileName: string): string => {
         var script = this.fileNameToScript[fileName];

--- a/lib/main/tsconfig/tsconfig.ts
+++ b/lib/main/tsconfig/tsconfig.ts
@@ -297,7 +297,9 @@ function rawToTsCompilerOptions(jsonOptions: CompilerOptions, projectDir: string
     var compilerOptions = <ts.CompilerOptions>mixin({}, defaults);
     for (var key in jsonOptions) {
         if (typescriptEnumMap[key]) {
-            compilerOptions[key] = typescriptEnumMap[key][jsonOptions[key].toLowerCase()];
+            let name = jsonOptions[key];
+            let map = typescriptEnumMap[key];
+            compilerOptions[key] = map[name.toLowerCase()] || map[name.toUpperCase()];
         }
         else {
             compilerOptions[key] = jsonOptions[key];


### PR DESCRIPTION
Since `ntypescript` still using `ts.getNewLineOrDefaultFromHost()` to
get new line character, we need provide `getNewLine` function in
`LanguageServiceHost`. Fix #545 