### PR TITLE
Grammar fixes

### DIFF
--- a/grammars/ts.cson
+++ b/grammars/ts.cson
@@ -837,13 +837,13 @@ repository:
     match: "\\*|/|\\-\\-|\\-|\\+\\+|\\+|%"
   "relational-operator":
     name: "keyword.operator.comparison.ts"
-    match: "===|==|=|!=|!==|<=|>=|<>|<|>"
+    match: "===|!==|==|!=|<=|>=|<>|=|<|>"
   "assignment-operator":
     name: "keyword.operator.assignment.ts"
-    match: "<<=|>>=|>>>=|\\*=|(?<!\\()/=|%=|\\+=|\\-=|&=|\\^="
+    match: "<<=|>>>=|>>=|\\*=|(?<!\\()/=|%=|\\+=|\\-=|&=|\\^="
   "logic-operator":
     name: "keyword.operator.arithmetic.ts"
-    match: "\\!|&|~|\\||&&|\\|\\|"
+    match: "\\!|&&|&|~|\\||\\|\\|"
   "storage-keyword":
     name: "storage.type.ts"
     match: "\\b(number|boolean|string|any|var|let|function|const)\\b"

--- a/grammars/tsx.cson
+++ b/grammars/tsx.cson
@@ -822,13 +822,13 @@ repository:
     match: "\\*|/|\\-\\-|\\-|\\+\\+|\\+|%"
   "relational-operator":
     name: "keyword.operator.comparison.tsx"
-    match: "===|==|=|!=|!==|<=|>=|<>|<|>"
+    match: "===|!==|==|!=|<=|>=|<>|=|<|>"
   "assignment-operator":
     name: "keyword.operator.assignment.tsx"
-    match: "<<=|>>=|>>>=|\\*=|(?<!\\()/=|%=|\\+=|\\-=|&=|\\^="
+    match: "<<=|>>>=|>>=|\\*=|(?<!\\()/=|%=|\\+=|\\-=|&=|\\^="
   "logic-operator":
     name: "keyword.operator.arithmetic.tsx"
-    match: "\\!|&|~|\\||&&|\\|\\|"
+    match: "\\!|&&|&|~|\\||\\|\\|"
   "storage-keyword":
     name: "storage.type.tsx"
     match: "\\b(number|boolean|string|any|var|let|function|const)\\b"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atom-typescript",
-  "version": "8.8.1",
+  "version": "8.8.2",
   "main": "./dist/main/atomts",
   "bin": {
     "atbuild": "./dist/main/bin/atbuild"


### PR DESCRIPTION
Matches the longer expression first : `&&` before `&` and `!==` before `!=`.