### PR TITLE
Load lib.d.ts from typescriptServices path

### DIFF
--- a/dist/main/lang/core/languageServiceHost2.js
+++ b/dist/main/lang/core/languageServiceHost2.js
@@ -3,6 +3,7 @@ var path = require('path');
 var fs = require('fs');
 var os = require('os');
 var textBuffer = require('basarat-text-buffer');
+var typescriptServices_1 = require("../typescriptServices");
 function createScriptInfo(fileName, text, isOpen) {
     if (isOpen === void 0) { isOpen = false; }
     var version = 1;
@@ -118,11 +119,19 @@ function getScriptSnapShot(scriptInfo) {
         getChangeRange: getChangeRange,
     };
 }
+function getTypescriptLocation() {
+    if (typescriptServices_1.typescriptServices) {
+        return path.dirname(typescriptServices_1.typescriptServices);
+    }
+    else {
+        return path.dirname(require.resolve('ntypescript'));
+    }
+}
 exports.getDefaultLibFilePath = function (options) {
     var filename = ts.getDefaultLibFileName(options);
-    return (path.join(path.dirname(require.resolve('ntypescript')), filename)).split('\\').join('/');
+    return (path.join(getTypescriptLocation(), filename)).split('\\').join('/');
 };
-exports.typescriptDirectory = path.dirname(require.resolve('ntypescript')).split('\\').join('/');
+exports.typescriptDirectory = getTypescriptLocation().split('\\').join('/');
 var LanguageServiceHost = (function () {
     function LanguageServiceHost(config) {
         var _this = this;

--- a/dist/main/lang/typescriptServices.js
+++ b/dist/main/lang/typescriptServices.js
@@ -1,0 +1,6 @@
+"use strict";
+exports.typescriptServices = '';
+function setTypescriptServices(path) {
+    exports.typescriptServices = path;
+}
+exports.setTypescriptServices = setTypescriptServices;

--- a/dist/worker/child.js
+++ b/dist/worker/child.js
@@ -5,6 +5,8 @@ if (process.argv.length > 2) {
 }
 var makeTypeScriptGlobal_1 = require("../typescript/makeTypeScriptGlobal");
 makeTypeScriptGlobal_1.makeTsGlobal(typescriptServices);
+var typescriptServices_1 = require("../main/lang/typescriptServices");
+typescriptServices_1.setTypescriptServices(typescriptServices);
 var workerLib = require('./lib/workerLib');
 var child = new workerLib.Child();
 var projectCache = require("../main/lang/projectCache");

--- a/lib/main/lang/core/languageServiceHost2.ts
+++ b/lib/main/lang/core/languageServiceHost2.ts
@@ -5,6 +5,7 @@ import os = require('os')
 import textBuffer = require('basarat-text-buffer');
 
 import tsconfig = require('../../tsconfig/tsconfig');
+import {typescriptServices} from "../typescriptServices";
 
 interface ScriptInfo {
     getFileName(): string;
@@ -203,12 +204,21 @@ function getScriptSnapShot(scriptInfo: ScriptInfo): ts.IScriptSnapshot {
     }
 }
 
-export var getDefaultLibFilePath = (options: ts.CompilerOptions) => {
-    var filename = ts.getDefaultLibFileName(options);
-    return (path.join(path.dirname(require.resolve('ntypescript')), filename)).split('\\').join('/');
+function getTypescriptLocation() {
+    if (typescriptServices) {
+        return path.dirname(typescriptServices);
+    }
+    else {
+        return path.dirname(require.resolve('ntypescript'));
+    }
 }
 
-export var typescriptDirectory = path.dirname(require.resolve('ntypescript')).split('\\').join('/');
+export var getDefaultLibFilePath = (options: ts.CompilerOptions) => {
+    var filename = ts.getDefaultLibFileName(options);
+    return (path.join(getTypescriptLocation(), filename)).split('\\').join('/');
+}
+
+export var typescriptDirectory = getTypescriptLocation().split('\\').join('/');
 
 
 // NOTES:

--- a/lib/main/lang/typescriptServices.ts
+++ b/lib/main/lang/typescriptServices.ts
@@ -1,0 +1,5 @@
+export var typescriptServices = '';
+
+export function setTypescriptServices(path: string) {
+    typescriptServices = path;
+}

--- a/lib/tsconfig.json
+++ b/lib/tsconfig.json
@@ -92,6 +92,7 @@
         "./main/lang/transformers/implementations/nullTransformer.ts",
         "./main/lang/transformers/transformer.ts",
         "./main/lang/transformers/transformerRegistry.ts",
+        "./main/lang/typescriptServices.ts",
         "./main/lang/utils.ts",
         "./main/react/htmltotsx.ts",
         "./main/tsconfig/dts-generator.ts",

--- a/lib/worker/child.ts
+++ b/lib/worker/child.ts
@@ -5,6 +5,8 @@ if (process.argv.length > 2) {
 // setup typescript
 import {makeTsGlobal} from "../typescript/makeTypeScriptGlobal";
 makeTsGlobal(typescriptServices);
+import {setTypescriptServices} from "../main/lang/typescriptServices";
+setTypescriptServices(typescriptServices);
 
 import workerLib = require('./lib/workerLib');
 


### PR DESCRIPTION
This is a fix for #923, to load default lib from custom `typescriptServices` path.