### PR TITLE
#726 adds show-type command for type info at cursor

### DIFF
--- a/dist/main/atom/views/typeOverlayView.js
+++ b/dist/main/atom/views/typeOverlayView.js
@@ -1,0 +1,13 @@
+"use strict";
+var escapeHtml = require('escape-html');
+function create(type, comment) {
+    var overlayHTML = "\n    <strong>" + escapeHtml(type) + "</strong>\n  ";
+    if (comment) {
+        overlayHTML += "\n      <br/>\n      <div class='comment'>\n        " + escapeHtml(comment).replace(/(?:\r\n|\r|\n)/g, '<br/>') + "\n      </div>\n    ";
+    }
+    var overlay = document.createElement('div');
+    overlay.className = 'atomts-show-type-view';
+    overlay.innerHTML = overlayHTML;
+    return overlay;
+}
+exports.create = create;

--- a/lib/main/atom/views/typeOverlayView.ts
+++ b/lib/main/atom/views/typeOverlayView.ts
@@ -1,0 +1,20 @@
+import escapeHtml = require('escape-html');
+
+export function create(type, comment) {
+  let overlayHTML = `
+    <strong>${escapeHtml(type)}</strong>
+  `;
+  if (comment) {
+    overlayHTML += `
+      <br/>
+      <div class='comment'>
+        ${escapeHtml(comment).replace(/(?:\r\n|\r|\n)/g, '<br/>')}
+      </div>
+    `;
+  }
+
+  const overlay = document.createElement('div');
+  overlay.className = 'atomts-show-type-view';
+  overlay.innerHTML = overlayHTML;
+  return overlay;
+}

--- a/lib/tsconfig.json
+++ b/lib/tsconfig.json
@@ -58,6 +58,7 @@
         "./main/atom/views/simpleOverlaySelectionView.ts",
         "./main/atom/views/simpleSelectionView.ts",
         "./main/atom/views/tooltipView.ts",
+        "./main/atom/views/typeOverlayView.ts",
         "./main/atom/views/view.ts",
         "./main/atomts.ts",
         "./main/bin/atbuild.ts",

--- a/styles/atomts-show-type-view.less
+++ b/styles/atomts-show-type-view.less
@@ -1,0 +1,8 @@
+@import 'ui-variables';
+
+.atomts-show-type-view {
+  background-color: @app-background-color;
+  border-radius: 3px;
+  box-shadow: 0 2px 8px 1px rgba(0, 0, 0, 0.3);
+  padding: 0.75em;
+}


### PR DESCRIPTION
This PR adds a `show-type` command that displays type information at the cursor. The overlay looks like this:
![screen shot 2016-06-05 at 10 22 35 pm](https://cloud.githubusercontent.com/assets/491393/15812701/e2691934-2b6c-11e6-8e92-f97c35df70ee.png)

Some notes:
* The type information overlay is dismissed when the cursor position changes, the escape key is pressed, or when the editor the overlay is in loses focus.
* I did not merge this code path with the one that displays type information on hover, mostly out of laziness.
* This is my first change on an Atom package so any improvement suggestions would be very welcome.