### PR TITLE
Fixed bug hyperclick not cover variable or method that have underscore

### DIFF
--- a/dist/hyperclickProvider.js
+++ b/dist/hyperclickProvider.js
@@ -4,7 +4,7 @@ var atomUtils = require("./main/atom/atomUtils");
 var immutable_1 = require("immutable");
 var TS_GRAMMARS = immutable_1.Set(["source.ts", "source.tsx"]);
 exports.providerName = "typescript-hyperclick-provider";
-exports.wordRegExp = /([A-Za-z0-9])+|['"`](\\.|[^'"`\\\\])*['"`]/g;
+exports.wordRegExp = /([A-Za-z0-9_])+|['"`](\\.|[^'"`\\\\])*['"`]/g;
 function getSuggestionForWord(textEditor, text, range) {
     return {
         range: range,

--- a/lib/hyperclickProvider.ts
+++ b/lib/hyperclickProvider.ts
@@ -6,7 +6,7 @@ const TS_GRAMMARS = Set<string>(["source.ts", "source.tsx"]);
 
 export let providerName = "typescript-hyperclick-provider";
 
-export let wordRegExp = /([A-Za-z0-9])+|['"`](\\.|[^'"`\\\\])*['"`]/g;
+export let wordRegExp = /([A-Za-z0-9_])+|['"`](\\.|[^'"`\\\\])*['"`]/g;
 
 export function getSuggestionForWord(textEditor: AtomCore.IEditor, text: string, range: TextBuffer.IRange) {
     return {


### PR DESCRIPTION
hyperclick not underline variable that has underscore case. see the picture below 

<img width="143" alt="screen shot 2559-07-12 at 2 17 40 pm" src="https://cloud.githubusercontent.com/assets/484530/16758399/704b96a6-483b-11e6-89fd-dd9ad5cb16a8.png">
