### PR TITLE
Support TS 2.0 flag noUnusedParameters

### DIFF
--- a/dist/main/tsconfig/tsconfig.js
+++ b/dist/main/tsconfig/tsconfig.js
@@ -44,6 +44,7 @@ var compilerOptionsValidation = {
     noLibCheck: { type: types.boolean },
     noResolve: { type: types.boolean },
     noUnusedLocals: { type: types.boolean },
+    noUnusedParameters: { type: types.boolean },
     out: { type: types.string },
     outFile: { type: types.string },
     outDir: { type: types.string },

--- a/lib/main/tsconfig/tsconfig.ts
+++ b/lib/main/tsconfig/tsconfig.ts
@@ -57,6 +57,7 @@ interface CompilerOptions {
     noLibCheck?: boolean;
     noResolve?: boolean;
     noUnusedLocals?: boolean;
+    noUnusedParameters?: boolean;
     out?: string;                                     // Deprecated. Use outFile instead
     outFile?: string;                                 // new name for out
     outDir?: string;                                  // Redirect output structure to this directory
@@ -120,6 +121,7 @@ var compilerOptionsValidation: simpleValidator.ValidationInfo = {
     noLibCheck: { type: types.boolean },
     noResolve: { type: types.boolean },
     noUnusedLocals: { type: types.boolean },
+    noUnusedParameters: { type: types.boolean },
     out: { type: types.string },
     outFile: { type: types.string },
     outDir: { type: types.string },


### PR DESCRIPTION
[ ] All compiled assets are included (atom packages are git tags and hence the built files need to be a part of the source control)


