### PR TITLE
Support the "types" compiler option in tsconfig.json.

### DIFF
--- a/dist/main/tsconfig/tsconfig.js
+++ b/dist/main/tsconfig/tsconfig.js
@@ -61,6 +61,7 @@ var compilerOptionsValidation = {
     suppressExcessPropertyErrors: { type: types.boolean },
     suppressImplicitAnyIndexErrors: { type: types.boolean },
     target: { type: types.string, validValues: ['es3', 'es5', 'es6', 'es2015'] },
+    types: { type: types.object },
     version: { type: types.boolean },
     watch: { type: types.boolean },
     lib: { type: types.array }

--- a/lib/main/tsconfig/tsconfig.ts
+++ b/lib/main/tsconfig/tsconfig.ts
@@ -73,6 +73,7 @@ interface CompilerOptions {
     suppressExcessPropertyErrors?: boolean;           // Optionally disable strict object literal assignment checking
     suppressImplicitAnyIndexErrors?: boolean;
     target?: string;                                  // 'es3'|'es5' (default)|'es6'|'es2015'
+    types?: string[];
     version?: boolean;
     watch?: boolean;
     lib?: string[];
@@ -137,6 +138,7 @@ var compilerOptionsValidation: simpleValidator.ValidationInfo = {
     suppressExcessPropertyErrors: { type: types.boolean },
     suppressImplicitAnyIndexErrors: { type: types.boolean },
     target: { type: types.string, validValues: ['es3', 'es5', 'es6', 'es2015'] },
+    types: { type: types.object },
     version: { type: types.boolean },
     watch: { type: types.boolean },
     lib: { type: types.array }


### PR DESCRIPTION
[x] All compiled assets are included (atom packages are git tags and hence the built files need to be a part of the source control)


Definition in commandLineParser.ts:
https://github.com/Microsoft/TypeScript/blob/f19844fbe97656a9e1f743fb6fe4e9d706a83c0d/src/compiler/commandLineParser.ts#L349