### PR TITLE
Support tsconfig "typeRoots" compiler option

### DIFF
--- a/dist/main/tsconfig/tsconfig.js
+++ b/dist/main/tsconfig/tsconfig.js
@@ -62,6 +62,7 @@ var compilerOptionsValidation = {
     suppressExcessPropertyErrors: { type: types.boolean },
     suppressImplicitAnyIndexErrors: { type: types.boolean },
     target: { type: types.string, validValues: ['es3', 'es5', 'es6', 'es2015'] },
+    typeRoots: { type: types.array },
     types: { type: types.object },
     version: { type: types.boolean },
     watch: { type: types.boolean },

--- a/lib/main/tsconfig/tsconfig.ts
+++ b/lib/main/tsconfig/tsconfig.ts
@@ -74,6 +74,7 @@ interface CompilerOptions {
     suppressExcessPropertyErrors?: boolean;           // Optionally disable strict object literal assignment checking
     suppressImplicitAnyIndexErrors?: boolean;
     target?: string;                                  // 'es3'|'es5' (default)|'es6'|'es2015'
+    typeRoots?: string[];
     types?: string[];
     version?: boolean;
     watch?: boolean;
@@ -140,6 +141,7 @@ var compilerOptionsValidation: simpleValidator.ValidationInfo = {
     suppressExcessPropertyErrors: { type: types.boolean },
     suppressImplicitAnyIndexErrors: { type: types.boolean },
     target: { type: types.string, validValues: ['es3', 'es5', 'es6', 'es2015'] },
+    typeRoots: { type: types.array },
     types: { type: types.object },
     version: { type: types.boolean },
     watch: { type: types.boolean },


### PR DESCRIPTION
[x] All compiled assets are included (atom packages are git tags and hence the built files need to be a part of the source control)

This pull request adds `typeRoots` compiler option in tsconfig. http://json.schemastore.org/tsconfig