### PR TITLE
Prevent returning suggestions for files that aren't TypeScript

### DIFF
--- a/dist/hyperclickProvider.js
+++ b/dist/hyperclickProvider.js
@@ -6,12 +6,12 @@ var TS_GRAMMARS = immutable_1.Set(["source.ts", "source.tsx"]);
 exports.providerName = "typescript-hyperclick-provider";
 exports.wordRegExp = /([A-Za-z0-9_])+|['"`](\\.|[^'"`\\\\])*['"`]/g;
 function getSuggestionForWord(textEditor, text, range) {
+    if (!TS_GRAMMARS.has(textEditor.getGrammar().scopeName)) {
+        return null;
+    }
     return {
         range: range,
         callback: function () {
-            if (!TS_GRAMMARS.has(textEditor.getGrammar().scopeName)) {
-                return null;
-            }
             var filePathPosition = {
                 filePath: textEditor.getPath(),
                 position: atomUtils.getEditorPositionForBufferPosition(textEditor, range.start)

--- a/lib/hyperclickProvider.ts
+++ b/lib/hyperclickProvider.ts
@@ -9,13 +9,13 @@ export let providerName = "typescript-hyperclick-provider";
 export let wordRegExp = /([A-Za-z0-9_])+|['"`](\\.|[^'"`\\\\])*['"`]/g;
 
 export function getSuggestionForWord(textEditor: AtomCore.IEditor, text: string, range: TextBuffer.IRange) {
+    if (!TS_GRAMMARS.has(textEditor.getGrammar().scopeName)) {
+        return null;
+    }
+
     return {
         range: range,
         callback() {
-            if (!TS_GRAMMARS.has(textEditor.getGrammar().scopeName)) {
-                return null;
-            }
-
             let filePathPosition = {
               filePath: textEditor.getPath(),
               position: atomUtils.getEditorPositionForBufferPosition(textEditor, range.start)


### PR DESCRIPTION
[x] All compiled assets are included (atom packages are git tags and hence the built files need to be a part of the source control)


Fixes #1062 

Fixes https://github.com/AsaAyers/js-hyperclick/issues/30
Refs https://github.com/AsaAyers/js-hyperclick/issues/31