### PR TITLE
Update ts.cson

### DIFF
--- a/grammars/ts.cson
+++ b/grammars/ts.cson
@@ -1018,7 +1018,8 @@ repository:
     end: "\\*/"
   "comment-line":
     name: "comment.line.ts"
-    match: "(//).*$\\n?"
+    begin: "//"
+    end: '$'
   literal:
     name: "literal.ts"
     patterns: [


### PR DESCRIPTION
[ x] All compiled assets are included (atom packages are git tags and hence the built files need to be a part of the source control)


Change detects TODO-like words so that they can be highlighted. Fixes https://github.com/TypeStrong/atom-typescript/issues/848