### PR TITLE
fix: tooltip contents floats out of the tooltip container

### DIFF
--- a/styles/atom-typescript-tooltip.less
+++ b/styles/atom-typescript-tooltip.less
@@ -8,5 +8,15 @@
     // This class exists by default and this is what we are using
     .tooltip-inner{
         text-align: left;
+        
+        b {
+            word-break: break-word;
+            word-wrap: break-word;
+            white-space: normal;
+        }
+        
+        i {
+            white-space: normal;
+        }
     }
 }


### PR DESCRIPTION
[ ] All compiled assets are included (atom packages are git tags and hence the built files need to be a part of the source control)

this should fix #919 

after this fix, tooltips should display like so: 
<img width="499" alt="screen shot 2016-09-07 at 10 35 37 am" src="https://cloud.githubusercontent.com/assets/878660/18303681/fe032306-74e6-11e6-936f-fc9736ae6d64.png">
<img width="500" alt="screen shot 2016-09-07 at 10 35 54 am" src="https://cloud.githubusercontent.com/assets/878660/18303682/fe08ff92-74e6-11e6-8357-ebc6e15f26db.png">

