### PR TITLE
Autocomplete does not suggestion options after typing '{'

### DIFF
--- a/dist/main/atom/autoCompleteProvider.js
+++ b/dist/main/atom/autoCompleteProvider.js
@@ -61,7 +61,7 @@ exports.provider = {
             }
             else {
                 var prefix = options.prefix.trim();
-                if (prefix === '' || prefix === ';') {
+                if (prefix === '' || prefix === ';' || prefix === '{') {
                     return Promise.resolve([]);
                 }
             }

--- a/lib/main/atom/autoCompleteProvider.ts
+++ b/lib/main/atom/autoCompleteProvider.ts
@@ -143,7 +143,7 @@ export var provider: autocompleteplus.Provider = {
             else { // else in special cases for automatic triggering refuse to provide completions
                 const prefix = options.prefix.trim()
 
-                if (prefix === '' || prefix === ';') {
+                if (prefix === '' || prefix === ';' || prefix === '{') {
                     return Promise.resolve([]);
                 }
             }


### PR DESCRIPTION
[ ] All compiled assets are included (atom packages are git tags and hence the built files need to be a part of the source control)

Resolves #1033 'Overly eager autocomplete after typing some characters'. 

I investigated whether it would be possible to only give autocomplete if the user types a character that is valid to start a variable name, but it turns out that's [quite complicated](http://stackoverflow.com/a/9337047/284741), particularly given that Javascript's regex engine does not have any inbuilt definitions of the relevant unicode groups. The quick fix I've added removes 90% of the irritation for me.


