### PR TITLE
Fix unknown skipLibCheck compiler option

### DIFF
--- a/lib/main/tsconfig/tsconfig.ts
+++ b/lib/main/tsconfig/tsconfig.ts
@@ -68,6 +68,7 @@ interface CompilerOptions {
     removeComments?: boolean;                         // Do not emit comments in output
     rootDir?: string;
     skipDefaultLibCheck?: boolean;
+    skipLibCheck?: boolean;
     sourceMap?: boolean;                              // Generates SourceMaps (.map files)
     sourceRoot?: string;                              // Optionally specifies the location where debugger should locate TypeScript source files after deployment
     stripInternal?: boolean;


### PR DESCRIPTION
[ ] All compiled assets are included (atom packages are git tags and hence the built files need to be a part of the source control)

fixes  #1046 
