### PR TITLE
Support for tsconfig "importHelpers"

### DIFF
--- a/dist/main/tsconfig/tsconfig.js
+++ b/dist/main/tsconfig/tsconfig.js
@@ -18,6 +18,7 @@ var compilerOptionsValidation = {
     emitDecoratorMetadata: { type: types.boolean },
     forceConsistentCasingInFileNames: { type: types.boolean },
     help: { type: types.boolean },
+    importHelpers: { type: types.boolean },
     inlineSourceMap: { type: types.boolean },
     inlineSources: { type: types.boolean },
     isolatedModules: { type: types.boolean },

--- a/lib/main/tsconfig/tsconfig.ts
+++ b/lib/main/tsconfig/tsconfig.ts
@@ -31,6 +31,7 @@ interface CompilerOptions {
     emitDecoratorMetadata?: boolean;                  // Experimental. Emits addition type information for this reflection API https://github.com/rbuckton/ReflectDecorators
     forceConsistentCasingInFileNames?: boolean;
     help?: boolean;
+    importHelpers?: boolean;
     isolatedModules?: boolean;
     inlineSourceMap?: boolean;
     inlineSources?: boolean;
@@ -97,6 +98,7 @@ var compilerOptionsValidation: simpleValidator.ValidationInfo = {
     emitDecoratorMetadata: { type: types.boolean },
     forceConsistentCasingInFileNames: { type: types.boolean },
     help: { type: types.boolean },
+    importHelpers: { type: types.boolean },
     inlineSourceMap: { type: types.boolean },
     inlineSources: { type: types.boolean },
     isolatedModules: { type: types.boolean },


### PR DESCRIPTION
- [x] All compiled assets are included (atom packages are git tags and hence the built files need to be a part of the source control)

This commit adds support for the new `importHelpers` flag (see [here](https://github.com/Microsoft/TypeScript/pull/9097)).

Interestingly when I ran `npm run build` it changed the 2 grammar files quite heavily, but I didn't include that in this commit/PR.