### PR TITLE
Add skipLibCheck and declarationDir tsconfig options

### DIFF
--- a/dist/main/tsconfig/tsconfig.js
+++ b/dist/main/tsconfig/tsconfig.js
@@ -1,6 +1,6 @@
 "use strict";
 var fsu = require("../utils/fsUtil");
-var simpleValidator = require('./simpleValidator');
+var simpleValidator = require("./simpleValidator");
 var types = simpleValidator.types;
 var compilerOptionsValidation = {
     allowJs: { type: types.boolean },
@@ -11,6 +11,7 @@ var compilerOptionsValidation = {
     charset: { type: types.string },
     codepage: { type: types.number },
     declaration: { type: types.boolean },
+    declarationDir: { type: types.string },
     diagnostics: { type: types.boolean },
     emitBOM: { type: types.boolean },
     experimentalAsyncFunctions: { type: types.boolean },
@@ -85,13 +86,13 @@ function errorWithDetails(error, details) {
     error.details = details;
     return error;
 }
-var fs = require('fs');
-var path = require('path');
-var tsconfig = require('tsconfig');
-var os = require('os');
-var detectIndent = require('detect-indent');
-var detectNewline = require('detect-newline');
-var formatting = require('./formatting');
+var fs = require("fs");
+var path = require("path");
+var tsconfig = require("tsconfig");
+var os = require("os");
+var detectIndent = require("detect-indent");
+var detectNewline = require("detect-newline");
+var formatting = require("./formatting");
 var projectFileName = 'tsconfig.json';
 var defaultFilesGlob = [
     "**/*.ts",

--- a/dist/main/tsconfig/tsconfig.js
+++ b/dist/main/tsconfig/tsconfig.js
@@ -1,6 +1,6 @@
 "use strict";
 var fsu = require("../utils/fsUtil");
-var simpleValidator = require("./simpleValidator");
+var simpleValidator = require('./simpleValidator');
 var types = simpleValidator.types;
 var compilerOptionsValidation = {
     allowJs: { type: types.boolean },
@@ -56,6 +56,7 @@ var compilerOptionsValidation = {
     removeComments: { type: types.boolean },
     rootDir: { type: types.string },
     skipDefaultLibCheck: { type: types.boolean },
+    skipLibCheck: { type: types.boolean },
     sourceMap: { type: types.boolean },
     sourceRoot: { type: types.string },
     strictNullChecks: { type: types.boolean },
@@ -64,7 +65,7 @@ var compilerOptionsValidation = {
     suppressImplicitAnyIndexErrors: { type: types.boolean },
     target: { type: types.string, validValues: ['es3', 'es5', 'es6', 'es2015'] },
     typeRoots: { type: types.array },
-    types: { type: types.object },
+    types: { type: types.array },
     version: { type: types.boolean },
     watch: { type: types.boolean },
     lib: { type: types.array }
@@ -84,13 +85,13 @@ function errorWithDetails(error, details) {
     error.details = details;
     return error;
 }
-var fs = require("fs");
-var path = require("path");
-var tsconfig = require("tsconfig");
-var os = require("os");
-var detectIndent = require("detect-indent");
-var detectNewline = require("detect-newline");
-var formatting = require("./formatting");
+var fs = require('fs');
+var path = require('path');
+var tsconfig = require('tsconfig');
+var os = require('os');
+var detectIndent = require('detect-indent');
+var detectNewline = require('detect-newline');
+var formatting = require('./formatting');
 var projectFileName = 'tsconfig.json';
 var defaultFilesGlob = [
     "**/*.ts",

--- a/lib/main/tsconfig/tsconfig.ts
+++ b/lib/main/tsconfig/tsconfig.ts
@@ -24,6 +24,7 @@ interface CompilerOptions {
     charset?: string;
     codepage?: number;
     declaration?: boolean;
+    declarationDir?: string;
     diagnostics?: boolean;
     emitBOM?: boolean;
     experimentalAsyncFunctions?: boolean;
@@ -92,6 +93,7 @@ var compilerOptionsValidation: simpleValidator.ValidationInfo = {
     charset: { type: types.string },
     codepage: { type: types.number },
     declaration: { type: types.boolean },
+    declarationDir: { type: types.string },
     diagnostics: { type: types.boolean },
     emitBOM: { type: types.boolean },
     experimentalAsyncFunctions: { type: types.boolean },

--- a/lib/main/tsconfig/tsconfig.ts
+++ b/lib/main/tsconfig/tsconfig.ts
@@ -69,6 +69,7 @@ interface CompilerOptions {
     removeComments?: boolean;                         // Do not emit comments in output
     rootDir?: string;
     skipDefaultLibCheck?: boolean;
+    skipLibCheck?: boolean;
     sourceMap?: boolean;                              // Generates SourceMaps (.map files)
     sourceRoot?: string;                              // Optionally specifies the location where debugger should locate TypeScript source files after deployment
     stripInternal?: boolean;
@@ -136,6 +137,7 @@ var compilerOptionsValidation: simpleValidator.ValidationInfo = {
     removeComments: { type: types.boolean },
     rootDir: { type: types.string },
     skipDefaultLibCheck: { type: types.boolean },
+    skipLibCheck: { type: types.boolean },
     sourceMap: { type: types.boolean },
     sourceRoot: { type: types.string },
     strictNullChecks: { type: types.boolean },
@@ -144,7 +146,7 @@ var compilerOptionsValidation: simpleValidator.ValidationInfo = {
     suppressImplicitAnyIndexErrors: { type: types.boolean },
     target: { type: types.string, validValues: ['es3', 'es5', 'es6', 'es2015'] },
     typeRoots: { type: types.array },
-    types: { type: types.object },
+    types: { type: types.array },
     version: { type: types.boolean },
     watch: { type: types.boolean },
     lib: { type: types.array }


### PR DESCRIPTION
- [x] All compiled assets are included (atom packages are git tags and hence the built files need to be a part of the source control)

Fixes #1085 
Closes #1081 
Fixes #1046