### PR TITLE
Fixed usage of deprecated electron env vars

### DIFF
--- a/dist/main/atom/commands/outputFileCommands.js
+++ b/dist/main/atom/commands/outputFileCommands.js
@@ -40,7 +40,12 @@ function register() {
             else {
                 var command = "node " + path.basename(res.jsFilePath);
                 console.log(command);
-                child_process_1.exec(command, { cwd: path.dirname(res.jsFilePath), env: { ATOM_SHELL_INTERNAL_RUN_AS_NODE: '1' } }, function (err, stdout, stderr) {
+                child_process_1.exec(command, {
+                    cwd: path.dirname(res.jsFilePath),
+                    env: {
+                        ELECTRON_RUN_AS_NODE: 1,
+                    },
+                }, function (err, stdout, stderr) {
                     console.log(stdout);
                     if (stderr.toString().trim().length) {
                         console.error(stderr);

--- a/dist/worker/lib/workerLib.js
+++ b/dist/worker/lib/workerLib.js
@@ -156,7 +156,7 @@ var Parent = (function (_super) {
         var _this = this;
         try {
             var spawnEnv = (process.platform === 'linux') ? Object.create(process.env) : {};
-            spawnEnv['ATOM_SHELL_INTERNAL_RUN_AS_NODE'] = '1';
+            spawnEnv['ELECTRON_RUN_AS_NODE'] = 1;
             this.child = spawn(this.node, [
                 childJsPath
             ].concat(customArguments), {

--- a/lib/main/atom/commands/outputFileCommands.ts
+++ b/lib/main/atom/commands/outputFileCommands.ts
@@ -47,7 +47,12 @@ export function register() {
                 var command = `node ${path.basename(res.jsFilePath) }`;
                 console.log(command);
 
-                exec(command, { cwd: path.dirname(res.jsFilePath), env: { ATOM_SHELL_INTERNAL_RUN_AS_NODE: '1' } }, (err, stdout, stderr) => {
+                exec(command, {
+                    cwd: path.dirname(res.jsFilePath),
+                    env: {
+                        ELECTRON_RUN_AS_NODE: 1,
+                    },
+                }, (err, stdout, stderr) => {
                     console.log(stdout);
                     if (stderr.toString().trim().length) {
                         console.error(stderr);

--- a/lib/worker/lib/workerLib.ts
+++ b/lib/worker/lib/workerLib.ts
@@ -235,7 +235,7 @@ export class Parent extends RequesterResponder {
                 dynamic libraries to be properly linked.
                 On Windows/MacOS, it needs to be cleared, cf. atom/atom#2887 */
             var spawnEnv = (process.platform === 'linux') ? Object.create(process.env) : {};
-            spawnEnv['ATOM_SHELL_INTERNAL_RUN_AS_NODE'] = '1';
+            spawnEnv['ELECTRON_RUN_AS_NODE'] = 1;
             this.child = spawn(this.node, [
             // '--debug', // Uncomment if you want to debug the child process
                 childJsPath


### PR DESCRIPTION
- [x] All compiled assets are included (atom packages are git tags and hence the built files need to be a part of the source control)

This PR fixes #1098 and adds support for Atom 1.12+. It'd be cool if you guys could release an update ASAP for the other beta testers. 🙂

It was caused by the removal of `ATOM_SHELL_INTERNAL_RUN_AS_NODE` from electron, which in turn has long been renamed to `ELECTRON_RUN_AS_NODE`.

P.S.:
> When I hit this really really annoying bug, it already seemed like something didn't run the `child.js` in a node process like it was supposed to, but instead tried to open or evaluate it which probably caused the file to open with the default file handler (at least that's what I thought). Searching for `child.js` and anything that launches or opens files lead me to `workerLib.ts` and the only `spawn()` in there with it's very suspicious env var. 😂 Best bugfix ever. 10/10 for being much easier than I thought it would be for once.