### PR TITLE
Update typescript, use byots and remove all references to ntypescript

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - "4.1"
+  - "6.3"
 sudo: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,11 +40,6 @@ And use `Shift+Delete` to delete files if simple `delete` doesn't work.
 
 # Various
 
-## NTypeScript
-We use a slightly modified (functionally equivalent) build of TypeScript called NTypeScript. The main motivation behind it is easier debugging and development workflow when consuming it as an NPM package. See [readme for details](https://github.com/TypeStrong/ntypescript#ntypescript).
-
-Update the version used by Atom-TypeScript using `npm install ntypescript@latest --save --save-exact` and then do some manual testing, and then rebuild the whole project.
-
 ## Publishing
 
 * If you have only fixed bugs in a backward-compatible way (or consider your changes very minimal), run `apm publish patch`.

--- a/dist/main/lang/core/languageServiceHost2.js
+++ b/dist/main/lang/core/languageServiceHost2.js
@@ -124,7 +124,7 @@ function getTypescriptLocation() {
         return path.dirname(typescriptServices_1.typescriptServices);
     }
     else {
-        return path.dirname(require.resolve('ntypescript'));
+        return path.dirname(require.resolve('typescript'));
     }
 }
 exports.getDefaultLibFilePath = function (options) {

--- a/dist/main/tsconfig/tsconfig.js
+++ b/dist/main/tsconfig/tsconfig.js
@@ -120,7 +120,7 @@ var typescriptEnumMap = {
     target: {
         'es3': ts.ScriptTarget.ES3,
         'es5': ts.ScriptTarget.ES5,
-        'es6': ts.ScriptTarget.ES6,
+        'es6': ts.ScriptTarget.ES2015,
         'latest': ts.ScriptTarget.Latest
     },
     module: {
@@ -129,7 +129,7 @@ var typescriptEnumMap = {
         'amd': ts.ModuleKind.AMD,
         'umd': ts.ModuleKind.UMD,
         'system': ts.ModuleKind.System,
-        'es6': ts.ModuleKind.ES6,
+        'es6': ts.ModuleKind.ES2015,
         'es2015': ts.ModuleKind.ES2015,
     },
     moduleResolution: {

--- a/dist/typescript/makeTypeScriptGlobal.js
+++ b/dist/typescript/makeTypeScriptGlobal.js
@@ -18,7 +18,7 @@ function makeTsGlobal(typescriptServices) {
         vm.runInContext(fs.readFileSync(typescriptServices).toString(), sandbox);
     }
     else {
-        sandbox.ts = require('ntypescript');
+        sandbox.ts = require('typescript');
     }
     global.ts = sandbox.ts;
 }

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -32,10 +32,10 @@ If you have `tsconfig.json` in a folder that contains `node_modules`, atom-types
 Set `compileOnSave : false` in your tsconfig.json (https://github.com/TypeStrong/atom-typescript/blob/master/docs/tsconfig.md#compileonsave).  Then you've got all the intellisense / refactoring goodness of atom-typescript but no generated JavaScript.  Why is this useful?  Well you might be using something else for your build such as [ts-loader](https://github.com/TypeStrong/ts-loader) or [tsify](https://github.com/TypeStrong/tsify) or [gulp-typescript](https://github.com/ivogabe/gulp-typescript).
 
 ## Which version of TypeScript does atom-typescript use?
-It uses [ntypescript](https://github.com/TypeStrong/ntypescript) which is just a build of Microsoft/Master.  This means it's the latest and greatest of the TypeScript goodness (You can see the last date it was updated in our [`package.json`](https://github.com/TypeStrong/atom-typescript/blob/master/package.json) e.g. `"ntypescript": "1.201603290104.1",` means `2016-03-29`).  There is a possibility that in the future it will move to TypeScript nightlies but our current automation is working well.
+You can see the date `typescript` dependency was updated in our [`package.json`](https://github.com/TypeStrong/atom-typescript/blob/master/package.json) e.g. `"typescript": "2.1.0-dev.20161023"` means it's using the nightly build published on `2016-10-23`).
 
 ## Can I use a custom TypeScript compiler?
-If it conforms the latest TypeScript services API then yes! Just set the path to `typescriptServices.js` in the package options.  
+If it conforms the latest TypeScript services API then yes! Just set the path to `typescriptServices.js` in the package options.
 
 ## Can I use an alternate transpiler?
 Atom-typescript supports using Babel as an alternate ES5 transpiler in coordination with the TypeScript language service.  This may be useful if TypeScript does not yet support transpiling a certain feature correctly (for example [scope per for loop iteration with let](https://github.com/Microsoft/TypeScript/issues/3915)).

--- a/lib/globals.ts
+++ b/lib/globals.ts
@@ -1,4 +1,3 @@
-/// <reference path="../node_modules/ntypescript/bin/ntypescript.d.ts"/>
 /// <reference path="../node_modules/tsconfig/dist/tsconfig.d.ts"/>
 /// <reference path="./typings/tsd.d.ts"/>
 

--- a/lib/main/lang/core/languageServiceHost2.ts
+++ b/lib/main/lang/core/languageServiceHost2.ts
@@ -209,7 +209,7 @@ function getTypescriptLocation() {
         return path.dirname(typescriptServices);
     }
     else {
-        return path.dirname(require.resolve('ntypescript'));
+        return path.dirname(require.resolve('typescript'));
     }
 }
 

--- a/lib/main/tsconfig/tsconfig.ts
+++ b/lib/main/tsconfig/tsconfig.ts
@@ -291,7 +291,7 @@ var typescriptEnumMap = {
     target: {
         'es3': ts.ScriptTarget.ES3,
         'es5': ts.ScriptTarget.ES5,
-        'es6': ts.ScriptTarget.ES6,
+        'es6': ts.ScriptTarget.ES2015,
         'latest': ts.ScriptTarget.Latest
     },
     module: {
@@ -300,7 +300,7 @@ var typescriptEnumMap = {
         'amd': ts.ModuleKind.AMD,
         'umd': ts.ModuleKind.UMD,
         'system': ts.ModuleKind.System,
-        'es6': ts.ModuleKind.ES6,
+        'es6': ts.ModuleKind.ES2015,
         'es2015': ts.ModuleKind.ES2015,
     },
     moduleResolution: {

--- a/lib/tsconfig.json
+++ b/lib/tsconfig.json
@@ -9,7 +9,10 @@
         "preserveConstEnums": true,
         "outDir": "../dist",
         "sourceMap": false,
-        "jsx": "react"
+        "jsx": "react",
+        "types": [
+            "byots"
+        ]
     },
     "dts": {
         "name": "atom-typescript"

--- a/lib/typescript/makeTypeScriptGlobal.ts
+++ b/lib/typescript/makeTypeScriptGlobal.ts
@@ -25,7 +25,7 @@ export function makeTsGlobal(typescriptServices?: string) {
         vm.runInContext(fs.readFileSync(typescriptServices).toString(), sandbox);
     }
     else {
-        sandbox.ts = require('ntypescript');
+        sandbox.ts = require('typescript');
     }
 
     // Finally export ts to the local global namespace

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "preferGlobal": "true",
   "description": "The only TypeScript plugin you will ever need.",
   "scripts": {
-    "test": "ntsc -p ./lib",
+    "test": "tsc -p ./lib",
     "build": "node scripts/grammar.js",
     "prepublish": "typings install"
   },
@@ -54,6 +54,7 @@
     "atom-space-pen-views": "^2.0.4",
     "babel": "^5.6.23",
     "basarat-text-buffer": "6.0.0",
+    "byots": "2.1.0-dev.20161022.0.26",
     "d3": "^3.5.5",
     "detect-indent": "^4.0.0",
     "detect-newline": "^2.1.0",
@@ -66,10 +67,10 @@
     "immutable": "^3.7.3",
     "json2dts": "0.0.1",
     "mkdirp": "^0.5.0",
-    "ntypescript": "1.201609302242.1",
     "react": "^0.13.3",
     "season": "^5.1.4",
     "tsconfig": "^2.2.0",
+    "typescript": "2.1.0-dev.20161023",
     "xtend": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- [x] All compiled assets are included (atom packages are git tags and hence the built files need to be a part of the source control)

This PR removes `ntypescript` as a dependency and instead uses `byots` (https://github.com/basarat/byots) to get Typescript's internal types as well as the official nightly Typescript package. This should help keep us up to date with the compiler. It's also step in the direction of potentially using the same Typescript package from the project that you're working on.