### PR TITLE
Update byots

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "atom-space-pen-views": "^2.0.4",
     "babel": "^5.6.23",
     "basarat-text-buffer": "6.0.0",
-    "byots": "2.1.0-dev.20161022.0.26",
+    "byots": "2.1.0-dev.20161029.21.55",
     "d3": "^3.5.5",
     "detect-indent": "^4.0.0",
     "detect-newline": "^2.1.0",


### PR DESCRIPTION
- [x] All compiled assets are included (atom packages are git tags and hence the built files need to be a part of the source control)

Fixes #1115