### PR TITLE
Fix the custom path to typescriptServices.js feature

### DIFF
--- a/dist/typescript/makeTypeScriptGlobal.js
+++ b/dist/typescript/makeTypeScriptGlobal.js
@@ -1,25 +1,18 @@
 "use strict";
-var vm = require("vm");
-var fs = require("fs");
+var path_1 = require("path");
 global.stack = function () {
     console.error(new Error().stack);
 };
-function makeTsGlobal(typescriptServices) {
-    var sandbox = {
-        ts: {},
-        console: console,
-        stack: global.stack,
-        require: require,
-        module: module,
-        process: process
-    };
-    vm.createContext(sandbox);
-    if (typescriptServices) {
-        vm.runInContext(fs.readFileSync(typescriptServices).toString(), sandbox);
+function makeTsGlobal(typescriptPath) {
+    if (typescriptPath) {
+        if (!path_1.isAbsolute(typescriptPath)) {
+            throw new Error("Path to Typescript \"" + typescriptPath + "\" is not absolute");
+        }
+        typescriptPath = typescriptPath.trim();
     }
     else {
-        sandbox.ts = require('typescript');
+        typescriptPath = "typescript";
     }
-    global.ts = sandbox.ts;
+    global.ts = require(typescriptPath);
 }
 exports.makeTsGlobal = makeTsGlobal;

--- a/lib/typescript/makeTypeScriptGlobal.ts
+++ b/lib/typescript/makeTypeScriptGlobal.ts
@@ -1,33 +1,21 @@
-////////////////////////////////// MAGIC
-import vm = require('vm');
-import fs = require('fs');
-import os = require('os');
-import path = require('path');
+import {isAbsolute} from "path"
 
+// Debugging helper
 global.stack = function() {
     console.error((<any>new Error()).stack);
 }
 
-/** Makes the bundled typescript services global or (if passed in) a custom typescriptServices file */
-export function makeTsGlobal(typescriptServices?: string) {
-    var sandbox = {
-        // This is going to gather the ts module exports
-        ts: {},
-        console: console,
-        stack: global.stack,
-        require: require,
-        module: module,
-        process: process
-    };
-    vm.createContext(sandbox);
-
-    if (typescriptServices) {
-        vm.runInContext(fs.readFileSync(typescriptServices).toString(), sandbox);
-    }
-    else {
-        sandbox.ts = require('typescript');
+// Export Typescript as a global. Takes an optional full path to typescriptServices.js
+export function makeTsGlobal(typescriptPath?: string) {
+  if (typescriptPath) {
+    if (!isAbsolute(typescriptPath)) {
+      throw new Error(`Path to Typescript "${typescriptPath}" is not absolute`)
     }
 
-    // Finally export ts to the local global namespace
-    global.ts = sandbox.ts;
+    typescriptPath = typescriptPath.trim()
+  } else {
+    typescriptPath = "typescript"
+  }
+
+  global.ts = require(typescriptPath);
 }


### PR DESCRIPTION
- [x] All compiled assets are included (atom packages are git tags and hence the built files need to be a part of the source control)

Code run with `vm.runInContext` is not wrapped with the helper that sets `__dirname` and `__filename` variables so it was throwing an error. A simple require is all that's needed in this case.
