### PR TITLE
Fix escaping of the results in reference view

### DIFF
--- a/dist/main/atom/commands/commands.js
+++ b/dist/main/atom/commands/commands.js
@@ -288,7 +288,7 @@ function registerCommands() {
             simpleSelectionView_1.simpleSelectionView({
                 items: res.references,
                 viewForItem: function (item) {
-                    return "<div>\n                        <span>" + atom.project.relativize(item.filePath) + "</span>\n                        <div class=\"pull-right\">line: " + (item.position.line + 1) + "</div>\n                        <ts-view>" + item.preview + "</ts-view>\n                    <div>";
+                    return "<div>\n                        <span>" + atom.project.relativize(item.filePath) + "</span>\n                        <div class=\"pull-right\">line: " + (item.position.line + 1) + "</div>\n                        <ts-view>" + escapeHtml(item.preview) + "</ts-view>\n                    <div>";
                 },
                 filterKey: utils.getName(function () { return res.references[0].filePath; }),
                 confirmed: function (definition) {

--- a/dist/main/atom/components/ts-view.js
+++ b/dist/main/atom/components/ts-view.js
@@ -4,14 +4,13 @@ var __extends = (this && this.__extends) || function (d, b) {
     function __() { this.constructor = d; }
     d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
-var escapeHtml = require("escape-html");
 var TsView = (function (_super) {
     __extends(TsView, _super);
     function TsView() {
         return _super.apply(this, arguments) || this;
     }
     TsView.prototype.createdCallback = function () {
-        var preview = escapeHtml(this.innerText);
+        var preview = this.innerText;
         this.innerText = "";
         var editorElement = this.editorElement = document.createElement('atom-text-editor');
         editorElement.setAttributeNode(document.createAttribute('gutter-hidden'));
@@ -19,13 +18,13 @@ var TsView = (function (_super) {
         var editor = this.editor = editorElement.getModel();
         editor.getDecorations({ class: 'cursor-line', type: 'line' })[0].destroy();
         editor.setText(preview);
-        var grammar = atom.grammars.grammarForScopeName("source.ts");
+        var grammar = atom.grammars.grammarForScopeName("source.tsx");
         editor.setGrammar(grammar);
         editor.setSoftWrapped(true);
         this.appendChild(editorElement);
     };
     TsView.prototype.text = function (text) {
-        this.editor.setText(escapeHtml(text));
+        this.editor.setText(text);
     };
     return TsView;
 }(HTMLElement));

--- a/lib/main/atom/commands/commands.ts
+++ b/lib/main/atom/commands/commands.ts
@@ -372,7 +372,7 @@ export function registerCommands() {
                     return `<div>
                         <span>${atom.project.relativize(item.filePath) }</span>
                         <div class="pull-right">line: ${item.position.line + 1}</div>
-                        <ts-view>${item.preview}</ts-view>
+                        <ts-view>${escapeHtml(item.preview)}</ts-view>
                     <div>`;
                 },
                 filterKey: utils.getName(() => res.references[0].filePath),

--- a/lib/main/atom/components/ts-view.ts
+++ b/lib/main/atom/components/ts-view.ts
@@ -1,13 +1,11 @@
 // Some docs
 // http://www.html5rocks.com/en/tutorials/webcomponents/customelements/ (look at lifecycle callback methods)
 
-import escapeHtml = require("escape-html");
-
 export class TsView extends HTMLElement {
     editorElement;
     editor;
     createdCallback() {
-        var preview = escapeHtml(this.innerText);
+        var preview = this.innerText;
         this.innerText = "";
 
         // Based on markdown editor
@@ -18,7 +16,7 @@ export class TsView extends HTMLElement {
         var editor = this.editor = (<any>editorElement).getModel();
         editor.getDecorations({ class: 'cursor-line', type: 'line' })[0].destroy(); // remove the default selection of a line in each editor
         editor.setText(preview);
-        var grammar = (<any>atom).grammars.grammarForScopeName("source.ts")
+        var grammar = (<any>atom).grammars.grammarForScopeName("source.tsx")
         editor.setGrammar(grammar);
         editor.setSoftWrapped(true);
 
@@ -27,7 +25,7 @@ export class TsView extends HTMLElement {
 
     // API
     text(text: string) {
-        this.editor.setText(escapeHtml(text));
+        this.editor.setText(text);
     }
 }
 


### PR DESCRIPTION
- [x] All compiled assets are included (atom packages are git tags and hence the built files need to be a part of the source control)

Fixes an issue with "Find references" view (perhaps others too) where some Typescript fragments would not be displayed correctly due to an escaping issue. This was especially painful when searching `.tsx` uses.

Before:
![image](https://cloud.githubusercontent.com/assets/679632/19909133/a626108e-a05c-11e6-83d1-97db9b9f085c.png)


After:
![image](https://cloud.githubusercontent.com/assets/679632/19909076/6e6484be-a05c-11e6-8dfd-c355c08c6441.png)

