### PR TITLE
Update module completion with the new scopes

### DIFF
--- a/dist/main/atom/autoCompleteProvider.js
+++ b/dist/main/atom/autoCompleteProvider.js
@@ -1,6 +1,5 @@
 "use strict";
 var parent = require("../../worker/parent");
-var atomConfig = require("./atomConfig");
 var fs = require("fs");
 var atomUtils = require("./atomUtils");
 var fuzzaldrin = require('fuzzaldrin');
@@ -11,6 +10,18 @@ function triggerAutocompletePlus() {
     explicitlyTriggered = true;
 }
 exports.triggerAutocompletePlus = triggerAutocompletePlus;
+function getModuleAutocompleteType(scopes) {
+    var has = scopes.reduce(function (scopes, name) {
+        scopes[name] = true;
+        return scopes;
+    }, {});
+    var isString = has['string.quoted.double.ts'] || has['string.quoted.single.ts'] || false;
+    return {
+        isReference: has['reference.path.string.quoted'] || has['amd.path.string.quoted'] || false,
+        isRequire: has['meta.import-equals.external.ts'] && isString || false,
+        isImport: has['meta.import.ts'] && isString || false
+    };
+}
 exports.provider = {
     selector: '.source.ts, .source.tsx',
     inclusionPriority: 3,
@@ -22,35 +33,25 @@ exports.provider = {
             return Promise.resolve([]);
         if (!fs.existsSync(filePath))
             return Promise.resolve([]);
-        var pathMatchers = ['reference.path.string.quoted', 'require.path.string.quoted', 'es6import.path.string.quoted'];
-        var lastScope = options.scopeDescriptor.scopes[options.scopeDescriptor.scopes.length - 1];
-        if (pathMatchers.some(function (p) { return lastScope === p; })) {
-            return parent.getRelativePathsInProject({ filePath: filePath, prefix: options.prefix, includeExternalModules: lastScope !== 'reference.path.string.quoted' })
+        var _a = getModuleAutocompleteType(options.scopeDescriptor.scopes), isReference = _a.isReference, isRequire = _a.isRequire, isImport = _a.isImport;
+        if (isReference || isRequire || isImport) {
+            return parent.getRelativePathsInProject({ filePath: filePath, prefix: options.prefix, includeExternalModules: isReference })
                 .then(function (resp) {
+                var range = options.editor.bufferRangeForScopeAtCursor(".string.quoted");
+                var cursor = options.editor.getCursorBufferPosition();
+                if (!range || cursor.column !== range.end.column - 1) {
+                    return [];
+                }
+                var content = options.editor.getTextInBufferRange(range).replace(/^['"]|['"]$/g, "");
                 return resp.files.map(function (file) {
                     var relativePath = file.relativePath;
                     var suggestionText = relativePath;
                     var suggestion = {
                         text: suggestionText,
-                        replacementPrefix: resp.endsInPunctuation ? '' : options.prefix.trim(),
+                        replacementPrefix: content,
                         rightLabelHTML: '<span>' + file.name + '</span>',
-                        type: 'path'
+                        type: 'import'
                     };
-                    if (lastScope == 'reference.path.string.quoted') {
-                        suggestion.atomTS_IsReference = {
-                            relativePath: relativePath
-                        };
-                    }
-                    if (lastScope == 'require.path.string.quoted') {
-                        suggestion.atomTS_IsImport = {
-                            relativePath: relativePath
-                        };
-                    }
-                    if (lastScope == 'es6import.path.string.quoted') {
-                        suggestion.atomTS_IsES6Import = {
-                            relativePath: relativePath
-                        };
-                    }
                     return suggestion;
                 });
             });
@@ -102,35 +103,4 @@ exports.provider = {
             return promisedSuggestions;
         }
     },
-    onDidInsertSuggestion: function (options) {
-        if (options.suggestion.atomTS_IsReference
-            || options.suggestion.atomTS_IsImport
-            || options.suggestion.atomTS_IsES6Import) {
-            var quote = (/["']/.exec(atomConfig.preferredQuoteCharacter) || [''])[0];
-            if (options.suggestion.atomTS_IsReference) {
-                options.editor.moveToBeginningOfLine();
-                options.editor.selectToEndOfLine();
-                options.editor.replaceSelectedText(null, function () { return '/// <reference path="' + options.suggestion.atomTS_IsReference.relativePath + '.ts"/>'; });
-            }
-            if (options.suggestion.atomTS_IsImport) {
-                options.editor.moveToBeginningOfLine();
-                options.editor.selectToEndOfLine();
-                var groups = /^(\s*)import\s*(\w*)\s*=\s*require\s*\(\s*(["'])/.exec(options.editor.getSelectedText());
-                var leadingWhiteSpace = groups[1];
-                var alias = groups[2];
-                quote = quote || groups[3];
-                options.editor.replaceSelectedText(null, function () { return leadingWhiteSpace + "import " + alias + " = require(" + quote + options.suggestion.atomTS_IsImport.relativePath + quote + ");"; });
-            }
-            if (options.suggestion.atomTS_IsES6Import) {
-                var row = options.editor.getCursorBufferPosition().row;
-                var originalText = options.editor.lineTextForBufferRow(row);
-                var groups = /(.*)from\s*(["'])/.exec(originalText);
-                var beforeFrom = groups[1];
-                quote = quote || groups[2];
-                var newTextAfterFrom = "from " + quote + options.suggestion.atomTS_IsES6Import.relativePath + quote + ";";
-                options.editor.setTextInBufferRange([[row, beforeFrom.length], [row, originalText.length]], newTextAfterFrom);
-            }
-            options.editor.moveToEndOfLine();
-        }
-    }
 };

--- a/dist/main/atom/autoCompleteProvider.js
+++ b/dist/main/atom/autoCompleteProvider.js
@@ -11,15 +11,14 @@ function triggerAutocompletePlus() {
 }
 exports.triggerAutocompletePlus = triggerAutocompletePlus;
 function getModuleAutocompleteType(scopes) {
-    var has = scopes.reduce(function (scopes, name) {
-        scopes[name] = true;
-        return scopes;
-    }, {});
-    var isString = has['string.quoted.double.ts'] || has['string.quoted.single.ts'] || false;
+    function has(match) {
+        return scopes.some(function (scope) { return scope.indexOf(match) !== -1; });
+    }
+    var isString = has('string.quoted');
     return {
-        isReference: has['reference.path.string.quoted'] || has['amd.path.string.quoted'] || false,
-        isRequire: has['meta.import-equals.external.ts'] && isString || false,
-        isImport: has['meta.import.ts'] && isString || false
+        isReference: has('reference.path.string.quoted') || has('amd.path.string.quoted'),
+        isRequire: has('meta.import-equals.external') && isString,
+        isImport: has('meta.import') && isString
     };
 }
 exports.provider = {

--- a/lib/main/atom/autoCompleteProvider.ts
+++ b/lib/main/atom/autoCompleteProvider.ts
@@ -73,17 +73,16 @@ function getModuleAutocompleteType(scopes: string[]): {
   isRequire: boolean, // this only matches: import hello = require("^cursor") and not require("^")
   isImport: boolean // ES6 import: import hello from "^cursor"
 } {
-  let has = scopes.reduce((scopes, name) => {
-    scopes[name] = true
-    return scopes
-  }, {} as {[key: string]: boolean})
+  function has(match: string): boolean {
+    return scopes.some(scope => scope.indexOf(match) !== -1)
+  }
 
-  let isString = has['string.quoted.double.ts'] || has['string.quoted.single.ts'] || false
+  let isString = has('string.quoted')
 
   return {
-    isReference: has['reference.path.string.quoted'] || has['amd.path.string.quoted'] || false,
-    isRequire: has['meta.import-equals.external.ts'] && isString || false,
-    isImport: has['meta.import.ts'] && isString || false
+    isReference: has('reference.path.string.quoted') || has('amd.path.string.quoted'),
+    isRequire: has('meta.import-equals.external') && isString,
+    isImport: has('meta.import') && isString
   }
 }
 


### PR DESCRIPTION
- [x] All compiled assets are included (atom packages are git tags and hence the built files need to be a part of the source control)

Fixes #1122
Fixes #1111

The scopes `atom-typescript` expected didn't match after updating the grammar. There are a few more places where the `es6import.path.string` scope is used so some stuff is still going to be broken.

Cleaned up some of the suggestion insertion logic to make sure whatever the user has already entered gets replaced and undo works as expected.