### PR TITLE
Add snippet to import using single quotes (as in Angular2)

### DIFF
--- a/snippets/typescript-snippets.cson
+++ b/snippets/typescript-snippets.cson
@@ -19,6 +19,11 @@
         'body': """
             import ${2} from "${1:path}";$3
         """
+    "import using '":
+        'prefix': 'importq'
+        'body': """
+            import ${2} from '${1:path}';$3
+        """
     'importr':
         'prefix': 'importr'
         'body': """


### PR DESCRIPTION
Add snippet to import using single quotes (as in Angular2, angular-cli, etc) as `importq`, additional to `import`.

I see this has been debated here https://github.com/TypeStrong/atom-typescript/issues/203 and here https://github.com/TypeStrong/atom-typescript/issues/259.

Right now the checks run OK, but the snippet generates imports with only double quote characters.

Using the `import` snippet generates an import statement with double quote characters (`"`), and if the preferred quote character was `'` it complains that they should be single quote characters. But currently there is no snippet to generate imports with single quote characters from the beginning.

I think this additional snippet might help keep happy both sides (single and double quote "sides").

---

> All compiled assets are included (atom packages are git tags and hence the built files need to be a part of the source control)

Note: there were no changes to TS files.

