### PR TITLE
As per the typescript handbook, allow "none" as a valid module.

### DIFF
--- a/dist/main/tsconfig/tsconfig.js
+++ b/dist/main/tsconfig/tsconfig.js
@@ -31,7 +31,7 @@ var compilerOptionsValidation = {
     listFiles: { type: types.boolean },
     locals: { type: types.string },
     mapRoot: { type: types.string },
-    module: { type: types.string, validValues: ['commonjs', 'amd', 'system', 'umd', 'es6', 'es2015'] },
+    module: { type: types.string, validValues: ['commonjs', 'amd', 'system', 'umd', 'es6', 'es2015', 'none'] },
     moduleResolution: { type: types.string, validValues: ['classic', 'node'] },
     newLine: { type: types.string },
     noEmit: { type: types.boolean },

--- a/lib/main/tsconfig/tsconfig.ts
+++ b/lib/main/tsconfig/tsconfig.ts
@@ -116,7 +116,7 @@ var compilerOptionsValidation: simpleValidator.ValidationInfo = {
     listFiles: { type: types.boolean },
     locals: { type: types.string },
     mapRoot: { type: types.string },
-    module: { type: types.string, validValues: ['commonjs', 'amd', 'system', 'umd', 'es6', 'es2015'] },
+    module: { type: types.string, validValues: ['commonjs', 'amd', 'system', 'umd', 'es6', 'es2015', 'none'] },
     moduleResolution: { type: types.string, validValues: ['classic', 'node'] },
     newLine: { type: types.string },
     noEmit: { type: types.boolean },


### PR DESCRIPTION
- [x] All compiled assets are included (atom packages are git tags and hence the built files need to be a part of the source control)

Very minimal change but makes the definition follow the handbook.
https://www.typescriptlang.org/docs/handbook/compiler-options.html

Closes #960.