### PR TITLE
Update TypeScript to v2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "react": "^0.13.3",
     "season": "^5.1.4",
     "tsconfig": "^2.2.0",
-    "typescript": "2.1.0-dev.20161023",
+    "typescript": "^2.1.4",
     "xtend": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- [x] All compiled assets are included (atom packages are git tags and hence the built files need to be a part of the source control)

TypeScript 2.1 is now [officially released](https://blogs.msdn.microsoft.com/typescript/2016/12/07/announcing-typescript-2-1/) – this PR updates `atom-typescript` to use v2.1, allowing object spread syntax etc.
