### PR TITLE
Bugfix/1108 Update deprecated CSS selector

### DIFF
--- a/styles/atomts-grammar-syntax.less
+++ b/styles/atomts-grammar-syntax.less
@@ -1,4 +1,4 @@
-atom-text-editor::shadow {
+atom-text-editor.editor {
     .source.ts,
     .source.tsx {
         .require.path, .reference.path, .es6import.path, .amd.path {


### PR DESCRIPTION
[ ] All compiled assets are included (atom packages are git tags and hence the built files need to be a part of the source control)

^ Not applicable for CSS changes, I'm guessing?

Quick fix for Issue #1108.