### PR TITLE
Remove css shadow selector

### DIFF
--- a/styles/atomts-grammar-syntax.less
+++ b/styles/atomts-grammar-syntax.less
@@ -1,4 +1,4 @@
-atom-text-editor::shadow {
+atom-text-editor {
     .source.ts,
     .source.tsx {
         .require.path, .reference.path, .es6import.path, .amd.path {


### PR DESCRIPTION
On atom 1.13 the ::shadow css selector was deprecated. 
I just removed it.