### PR TITLE
quickfix to fall back to closest error in the file

### DIFF
--- a/lib/main/lang/projectService.ts
+++ b/lib/main/lang/projectService.ts
@@ -860,7 +860,7 @@ function findClosestErrorPosition(fileErrors: ts.Diagnostic[], position: number)
   const newPos = fileErrors
     .map(i => [Math.min(Math.abs(position - i.start), Math.abs(position - i.start - i.length)), i.start])
     .reduce((acc, val) => val[0] < acc[0] || acc[0] === -1 ? val : acc, [-1, -1]);
-  return newPos[1];
+  return newPos[1] !== -1 ? newPos[1] : position;
 }
 
 export interface GetQuickFixesQuery extends FilePathPositionQuery { }


### PR DESCRIPTION
[ ] All compiled assets are included (atom packages are git tags and hence the built files need to be a part of the source control)

See https://github.com/TypeStrong/atom-typescript/issues/1191.
This PR makes quickfix to fall back to the closest error in the current file in case no error is on the position of the cursor.