### PR TITLE
[fix error] Deprecated selector

### DIFF
--- a/styles/highlights.less
+++ b/styles/highlights.less
@@ -1,6 +1,6 @@
 @import "ui-variables";
 
-atom-text-editor::shadow {
+atom-text-editor.editor {
   .highlights {
     .atom-typescript-occurrence {
       .region {


### PR DESCRIPTION
Starting from Atom v1.13.0, the contents of atom-text-editor elements are no longer encapsulated within a shadow DOM boundary. This means you should stop using :host and ::shadow pseudo-selectors, and prepend all your syntax selectors with syntax--. To prevent breakage with existing style sheets, Atom will automatically upgrade the following selectors:

atom-text-editor::shadow .highlights .atom-typescript-occurrence .region => atom-text-editor.editor .highlights .atom-typescript-occurrence .region
Automatic translation of selectors will be removed in a few release cycles to minimize startup time. Please, make sure to upgrade the above selectors as soon as possible.

[ ] All compiled assets are included (atom packages are git tags and hence the built files need to be a part of the source control)

