### PR TITLE
[fix #1171] Object.basename is deprecated

### DIFF
--- a/lib/main/atom/tooltipManager.ts
+++ b/lib/main/atom/tooltipManager.ts
@@ -28,6 +28,9 @@ export function attach(editorView: JQuery, editor: AtomCore.IEditor) {
 
     // Only on ".ts" files
     var filePath = editor.getPath();
+    if (!filePath) {
+      return;
+    }
     var filename = path.basename(filePath);
     var ext = path.extname(filename);
     if (!atomUtils.isAllowedExtension(ext)) return;


### PR DESCRIPTION
Arguments to path.basename must be strings

[ ] All compiled assets are included (atom packages are git tags and hence the built files need to be a part of the source control)

