### PR TITLE
[fix #1150] deprecated error

### DIFF
--- a/lib/main/atom/tooltipManager.ts
+++ b/lib/main/atom/tooltipManager.ts
@@ -47,7 +47,7 @@ export function attach(editorView: JQuery, editor: AtomCore.IEditor) {
 
     subscriber.subscribe(scroll, 'mousemove', (e) => {
         var pixelPt = pixelPositionFromMouseEvent(editorView, e)
-        var screenPt = editor.screenPositionForPixelPosition(pixelPt)
+        var screenPt = editor.element.screenPositionForPixelPosition(pixelPt)
         var bufferPt = editor.bufferPositionForScreenPosition(screenPt)
         if (lastExprTypeBufferPt && lastExprTypeBufferPt.isEqual(bufferPt) && exprTypeTooltip)
             return;
@@ -69,9 +69,9 @@ export function attach(editorView: JQuery, editor: AtomCore.IEditor) {
         if (exprTypeTooltip) return;
 
         var pixelPt = pixelPositionFromMouseEvent(editorView, e);
-        pixelPt.top += editor.getScrollTop();
-        pixelPt.left += editor.getScrollLeft();
-        var screenPt = editor.screenPositionForPixelPosition(pixelPt);
+        pixelPt.top += editor.element.getScrollTop();
+        pixelPt.left += editor.element.getScrollLeft();
+        var screenPt = editor.element.screenPositionForPixelPosition(pixelPt);
         var bufferPt = editor.bufferPositionForScreenPosition(screenPt);
         var curCharPixelPt = rawView.pixelPositionForBufferPosition([bufferPt.row, bufferPt.column]);
         var nextCharPixelPt = rawView.pixelPositionForBufferPosition([bufferPt.row, bufferPt.column + 1]);


### PR DESCRIPTION
fix -> https://github.com/TypeStrong/atom-typescript/issues/1150

[ ] All compiled assets are included (atom packages are git tags and hence the built files need to be a part of the source control)

