### PR TITLE
Add/remove 'typescript-editor' class from <atom-text-editor> elements where typescript is active

### DIFF
--- a/dist/main/atom/editorSetup.js
+++ b/dist/main/atom/editorSetup.js
@@ -1,4 +1,9 @@
 "use strict";
 function setupEditor(editor) {
+    var editorView = atom.views.getView(editor);
+    editorView.classList.add('typescript-editor');
+    editor.onDidDestroy(function () {
+        editorView.classList.remove('typescript-editor');
+    });
 }
 exports.setupEditor = setupEditor;

--- a/lib/main/atom/editorSetup.ts
+++ b/lib/main/atom/editorSetup.ts
@@ -7,6 +7,16 @@ import * as atomUtils from "./atomUtils";
 import {isTransformerFile} from "../lang/transformers/transformer";
 
 export function setupEditor(editor: AtomCore.IEditor) {
+
+    const editorView: HTMLElement = atom.views.getView(editor);
+
+    // Add and remove 'typescript-editor' class from the <atom-text-editor>
+    // where typescript is active.
+    editorView.classList.add('typescript-editor');
+    editor.onDidDestroy(() => {
+        editorView.classList.remove('typescript-editor');
+    });
+
     //
     // // Quick fix decoration stuff
     // var quickFixDecoration: AtomCore.Decoration = null;


### PR DESCRIPTION
Fix #1199 by adding the `typescript-editor` class to the editor where `typescript` is activated and removing this class when the editor is destroyed.

[x] All compiled assets are included (atom packages are git tags and hence the built files need to be a part of the source control)

