### PR TITLE
[fix #1150] deprecated error

### DIFF
--- a/lib/typings/atom/atom.d.ts
+++ b/lib/typings/atom/atom.d.ts
@@ -563,6 +563,8 @@ declare module AtomCore {
 		subscriptionsByObject: any; /* WeakMap */
 		subscriptions: Emissary.ISubscription[];
 
+                editor: any;
+
 		serializeParams():{id:number; softTabs:boolean; scrollTop:number; scrollLeft:number; displayBuffer:any;};
 		deserializeParams(params:any):any;
 		subscribeToBuffer():void;


### PR DESCRIPTION
[ ] All compiled assets are included (atom packages are git tags and hence the built files need to be a part of the source control)

