### PR TITLE
Quickfix trigger on file: fix off by one error

### DIFF
--- a/lib/main/lang/projectService.ts
+++ b/lib/main/lang/projectService.ts
@@ -852,8 +852,7 @@ function getInfoForQuickFixAnalysis(query: FilePathPositionQuery): QuickFixQuery
 }
 
 function getPositionErrors(fileErrors: ts.Diagnostic[], position: number) {
-  /** We want errors that are *touching* and thefore expand the query position by one */
-  return fileErrors.filter(e=> ((e.start - 1) < position) && (e.start + e.length + 1) > position)
+  return fileErrors.filter(e => (e.start <= position) && ((e.start + e.length) > position));
 }
 
 function findClosestErrorPosition(fileErrors: ts.Diagnostic[], position: number) {


### PR DESCRIPTION
- [ ] All compiled assets are included (atom packages are git tags and hence the built files need to be a part of the source control)

This is a follow up to #1193. See also issue #1191. 

This is a fix for a small leftover bug:
When the cursor is just after the error, passing the current position to the quickfix (e.g., import) won't trigger because the qf's inner filter does not allow that. 

Let's rely on the search for the closest error in this case too.