### PR TITLE
Support showing 'unused' ts errors with severity 'info'

### DIFF
--- a/dist/main/atomts.js
+++ b/dist/main/atomts.js
@@ -39,6 +39,10 @@ function activate(state) {
         });
         subscriptions.add(statusPanel);
         const errorPusher = new errorPusher_1.ErrorPusher();
+        errorPusher.setUnusedAsInfo(atom.config.get('atom-typescript.unusedAsInfo'));
+        subscriptions.add(atom.config.onDidChange('atom-typescript.unusedAsInfo', (val) => {
+            errorPusher.setUnusedAsInfo(val.newValue);
+        }));
         exports.clientResolver.on("pendingRequestsChange", () => {
             const pending = lodash_2.flatten(lodash_2.values(exports.clientResolver.clients).map(cl => cl.pending));
             statusPanel.setPending(pending);

--- a/dist/main/atomts.js
+++ b/dist/main/atomts.js
@@ -39,8 +39,8 @@ function activate(state) {
         });
         subscriptions.add(statusPanel);
         const errorPusher = new errorPusher_1.ErrorPusher();
-        errorPusher.setUnusedAsInfo(atom.config.get('atom-typescript.unusedAsInfo'));
-        subscriptions.add(atom.config.onDidChange('atom-typescript.unusedAsInfo', (val) => {
+        errorPusher.setUnusedAsInfo(atom.config.get("atom-typescript.unusedAsInfo"));
+        subscriptions.add(atom.config.onDidChange("atom-typescript.unusedAsInfo", (val) => {
             errorPusher.setUnusedAsInfo(val.newValue);
         }));
         exports.clientResolver.on("pendingRequestsChange", () => {

--- a/dist/main/atomts.js
+++ b/dist/main/atomts.js
@@ -138,6 +138,14 @@ function provide() {
     ];
 }
 exports.provide = provide;
+exports.config = {
+    unusedAsInfo: {
+        title: 'Show unused values with severity info',
+        description: 'Show unused values with severety \'info\' instead of \'error\'',
+        type: 'boolean',
+        default: true
+    }
+};
 function loadProjectConfig(sourcePath) {
     return exports.clientResolver.get(sourcePath).then(client => {
         return client.executeProjectInfo({ needFileNameList: false, file: sourcePath }).then(result => {

--- a/dist/main/errorPusher.js
+++ b/dist/main/errorPusher.js
@@ -26,10 +26,6 @@ class ErrorPusher {
                 this.linter.setMessages(errors);
             }
         }, 100);
-        this.unusedAsInfo = atom.config.get('atom-typescript.unusedAsInfo');
-        atom.config.onDidChange('atom-typescript.unusedAsInfo', (val) => {
-            this.unusedAsInfo = val.newValue;
-        });
     }
     /** Set errors. Previous errors with the same prefix and filePath are going to be replaced */
     setErrors(prefix, filePath, errors) {
@@ -44,6 +40,9 @@ class ErrorPusher {
         }
         prefixed.set(filePath, errors);
         this.pushErrors();
+    }
+    setUnusedAsInfo(unusedAsInfo) {
+        this.unusedAsInfo = unusedAsInfo;
     }
     /** Clear all errors */
     clear() {

--- a/dist/main/errorPusher.js
+++ b/dist/main/errorPusher.js
@@ -14,7 +14,7 @@ class ErrorPusher {
                     const _filePath = utils_1.systemPath(filePath);
                     for (const diagnostic of diagnostics) {
                         errors.push({
-                            type: this.unusedAsInfo && diagnostic.text.indexOf(' is declared but never used') > 0 ? "Info" : "Error",
+                            type: this.unusedAsInfo && diagnostic.code === 6133 ? "Info" : "Error",
                             text: diagnostic.text,
                             filePath: _filePath,
                             range: diagnostic.start ? utils_1.locationsToRange(diagnostic.start, diagnostic.end) : undefined

--- a/lib/main/atomts.ts
+++ b/lib/main/atomts.ts
@@ -49,6 +49,10 @@ export function activate(state: PackageState) {
     subscriptions.add(statusPanel)
 
     const errorPusher = new ErrorPusher()
+    errorPusher.setUnusedAsInfo(atom.config.get('atom-typescript.unusedAsInfo'));
+    subscriptions.add((<any>atom.config).onDidChange('atom-typescript.unusedAsInfo', (val:{oldValue:boolean, newValue:boolean}) => {
+      errorPusher.setUnusedAsInfo(val.newValue);
+    }))
 
     clientResolver.on("pendingRequestsChange", () => {
       const pending = flatten(values(clientResolver.clients).map(cl => cl.pending))

--- a/lib/main/atomts.ts
+++ b/lib/main/atomts.ts
@@ -33,7 +33,7 @@ export function activate(state: PackageState) {
     let statusPriority = 100
     for (const panel of statusBar.getRightTiles()) {
       if (panel.getItem().tagName === "GRAMMAR-SELECTOR-STATUS") {
-        statusPriority = panel.getPriority() - 1
+      statusPriority = panel.getPriority() - 1
       }
     }
 
@@ -47,12 +47,13 @@ export function activate(state: PackageState) {
     })
 
     subscriptions.add(statusPanel)
-
     const errorPusher = new ErrorPusher()
-    errorPusher.setUnusedAsInfo(atom.config.get('atom-typescript.unusedAsInfo'));
-    subscriptions.add((<any>atom.config).onDidChange('atom-typescript.unusedAsInfo', (val:{oldValue:boolean, newValue:boolean}) => {
-      errorPusher.setUnusedAsInfo(val.newValue);
-    }))
+    errorPusher.setUnusedAsInfo(atom.config.get("atom-typescript.unusedAsInfo"))
+    subscriptions.add(atom.config.onDidChange("atom-typescript.unusedAsInfo",
+      (val:{oldValue:boolean, newValue:boolean}) => {
+        errorPusher.setUnusedAsInfo(val.newValue)
+      }
+    ))
 
     clientResolver.on("pendingRequestsChange", () => {
       const pending = flatten(values(clientResolver.clients).map(cl => cl.pending))

--- a/lib/main/atomts.ts
+++ b/lib/main/atomts.ts
@@ -162,6 +162,14 @@ export function provide() {
     new AutocompleteProvider(clientResolver, {getTypescriptBuffer}),
   ]
 }
+export var config = {
+  unusedAsInfo: {
+    title: 'Show unused values with severity info',
+    description: 'Show unused values with severety \'info\' instead of \'error\'',
+    type: 'boolean',
+    default: true
+  }
+}
 
 export function loadProjectConfig(sourcePath: string): Promise<tsconfig.TSConfig> {
   return clientResolver.get(sourcePath).then(client => {

--- a/lib/main/errorPusher.ts
+++ b/lib/main/errorPusher.ts
@@ -52,7 +52,7 @@ export class ErrorPusher {
         const _filePath = systemPath(filePath)
         for (const diagnostic of diagnostics) {
           errors.push({
-            type: this.unusedAsInfo && diagnostic.text.indexOf(' is declared but never used') > 0?"Info":"Error",
+            type: this.unusedAsInfo && diagnostic.code === 6133 ?"Info":"Error",
             text: diagnostic.text,
             filePath: _filePath,
             range: diagnostic.start ? locationsToRange(diagnostic.start, diagnostic.end) : undefined

--- a/lib/main/errorPusher.ts
+++ b/lib/main/errorPusher.ts
@@ -8,12 +8,7 @@ export class ErrorPusher {
   private linter?: Linter
   private errors: Map<string, Map<string, Diagnostic[]>> = new Map()
   private unusedAsInfo = true;
-  constructor() {
-    this.unusedAsInfo = atom.config.get('atom-typescript.unusedAsInfo');
-    (<any>atom.config).onDidChange('atom-typescript.unusedAsInfo', (val:{oldValue:boolean, newValue:boolean}) => {
-      this.unusedAsInfo = val.newValue;
-    })
-  }
+
   /** Set errors. Previous errors with the same prefix and filePath are going to be replaced */
   setErrors(prefix: string | undefined, filePath: string | undefined, errors: Diagnostic[]) {
     if (prefix == undefined || filePath == undefined) {
@@ -30,6 +25,10 @@ export class ErrorPusher {
     prefixed.set(filePath, errors)
 
     this.pushErrors()
+  }
+
+  setUnusedAsInfo(unusedAsInfo: boolean) {
+    this.unusedAsInfo = unusedAsInfo;
   }
 
   /** Clear all errors */

--- a/lib/main/errorPusher.ts
+++ b/lib/main/errorPusher.ts
@@ -7,7 +7,7 @@ import {locationsToRange, systemPath} from "./atom/utils"
 export class ErrorPusher {
   private linter?: Linter
   private errors: Map<string, Map<string, Diagnostic[]>> = new Map()
-  private unusedAsInfo = true;
+  private unusedAsInfo = true
 
   /** Set errors. Previous errors with the same prefix and filePath are going to be replaced */
   setErrors(prefix: string | undefined, filePath: string | undefined, errors: Diagnostic[]) {
@@ -28,7 +28,7 @@ export class ErrorPusher {
   }
 
   setUnusedAsInfo(unusedAsInfo: boolean) {
-    this.unusedAsInfo = unusedAsInfo;
+    this.unusedAsInfo = unusedAsInfo
   }
 
   /** Clear all errors */

--- a/lib/typings/atom_core.d.ts
+++ b/lib/typings/atom_core.d.ts
@@ -2,7 +2,9 @@ declare namespace AtomCore {
   interface IEditor {
     onDidChangeGrammar(callback: (grammar: IGrammar) => any): Disposable
   }
-
+  interface IConfig {
+    onDidChange(opt:string, callback: (val:{oldValue:any, newValue:any}) => void): Disposable
+  }
   interface CommandEvent extends Event {
     abortKeyBinding(): any
   }


### PR DESCRIPTION
- [x] All compiled assets are included (atom packages are git tags and hence the built files need to be a part of the source control)

I had some issues due to TS and atom-TS treating everything with severity `Error`. 
Particularly situations where you'd like to be notified of the occasional unused variable / parameter, but where you don't want these notifications to clutter your interface that much that you'll miss the more severe TS errors.

Things in this PR are:
- Added an atom-typescript option that shows unused values with severity `info` (defaults to `true`)
- Modified the `errorPusher` file to check the error message, and switch to severity `info` when the above option is set.

Particularly the last item might need some discussion: I'm simply applying a string-match that checks for substring ` is declared but never used`. Ideally I'd like to be able to use TS error codes or something, but afaik the only information I could act on was this error message. This makes it a bit error prone, e.g. when MS changes the error message, or when translations are added to TS or this plugin.
If somebody has a better idea, let me know

ps. this resolves #1018
pps. chose severity `info` instead of `warning` because the default linter colors for `warning` and `error` are too similar in my opinion.