### PR TITLE
rootElement is deprecated

### DIFF
--- a/lib/main/atom/tooltipManager.ts
+++ b/lib/main/atom/tooltipManager.ts
@@ -15,7 +15,10 @@ import escape = require("escape-html")
 
 export function getFromShadowDom(element: JQuery, selector: string): JQuery {
   var el = element[0]
-  var found = (<any>el).rootElement.querySelectorAll(selector)
+  var found = (<any> el).querySelectorAll(selector)
+  if (!found) {
+    found = (<any> el).rootElement.querySelectorAll(selector)
+  }
   return $(found[0])
 }
 


### PR DESCRIPTION
HTMLElement.rootElement is deprecated in Atom 1.19, fixes #1274, fixes #1275 (duplicate).
Backwards compatible change (doesn't break in 1.18)

- [ ] Include compiled assets

Compiled assets are not included, I'll include them later. Don't merge yet

