### PR TITLE
Remove conflicting typescript:quick-fix from keymap

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ Shortcut `shift+F12`. Also called *find usages*.
 ![](https://raw.githubusercontent.com/TypeStrong/atom-typescript/master/docs/screens/renameRefactoring.png)
 
 ## Quick Fix
-Current iteration of the plugin doesn't support any Quickfixes, but they're coming in the future.
+Shortcut : `ctrl+enter` on a Mac and `alt+enter` for Windows and Linux.
+Currently available codefixes:
+https://github.com/Microsoft/TypeScript/tree/master/src/services/codefixes
 
 ## Contributing
 

--- a/keymaps/atom-typescript.cson
+++ b/keymaps/atom-typescript.cson
@@ -5,7 +5,6 @@
   'cmd-;': 'typescript:context-actions'
   'f2': 'typescript:rename-refactor'
   'shift-f12': 'typescript:find-references'
-  'alt-enter': 'typescript:quick-fix'
   'ctrl-M': 'typescript:output-toggle'
   'cmd-M': 'typescript:output-toggle'
 


### PR DESCRIPTION
remove `typescript:quick-fix` from keymap, it does nothing and conflict `intentions:show`, resulting in codefixes unusable on linux or windows without editing keymap.

also document codefixes in readme
