### PR TITLE
Correct link to change log

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,4 +109,4 @@ https://github.com/Microsoft/TypeScript/tree/master/src/services/codefixes
 Look at [CONTRIBUTING.md](https://github.com/TypeStrong/atom-typescript/blob/master/CONTRIBUTING.md) for curiosity. We work hard to keep the code as approachable as possible and are highly keen on helping you help us.
 
 ## Changelog
-Breaking changes [available online](https://github.com/TypeStrong/atom-typescript/blob/master/docs/CHANGELOG.md).
+Breaking changes [available online](https://github.com/TypeStrong/atom-typescript/blob/master/CHANGELOG.md).


### PR DESCRIPTION
The link pointed to a non-existent file in a different location,
I presume that it was simply outdated.

- [ ] All compiled assets are included (atom packages are git tags and hence the built files need to be a part of the source control)  <-- Can I assume that this isn't relevant for a documentation-only fix?

