### PR TITLE
Fix spelling of “TypeScript”

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,15 +103,15 @@ point](https://raw.githubusercontent.com/TypeStrong/atom-typescript/master/docs/
 
 ## Compile on save
 
-When `"compileOnSave": true` is set in `tsconfig.json`, Typescript files
+When `"compileOnSave": true` is set in `tsconfig.json`, TypeScript files
 will be compiled and saved automatically. The compiler does its best to
 emit something, even if there are semantic errors in the file.
 
 ## Project Support
 
-`atom-typescript` supports all the same options the Typescript compiler
+`atom-typescript` supports all the same options the TypeScript compiler
 does as it's using it behind the scenes to do all of the heavy lifting.
-In fact, `atom-typescript` will use the exact version of Typescript you
+In fact, `atom-typescript` will use the exact version of TypeScript you
 have installed in your `node_modules` directory.
 
 ## Format Code

--- a/dist/client/client.js
+++ b/dist/client/client.js
@@ -49,7 +49,7 @@ class TypescriptServiceClient {
                 if (this.lastStderrOutput) {
                     detail = `Last output from tsserver:\n${this.lastStderrOutput}\n\n${detail}`;
                 }
-                atom.notifications.addError("Typescript quit unexpectedly", {
+                atom.notifications.addError("TypeScript quit unexpectedly", {
                     detail,
                     stack: err.stack,
                     dismissable: true,

--- a/dist/client/clientResolver.js
+++ b/dist/client/clientResolver.js
@@ -13,7 +13,7 @@ class ClientResolver {
         this.clients = new Map();
         this.emitter = new atom_1.Emitter();
     }
-    // This is just here so Typescript can infer the types of the callbacks when using "on" method
+    // This is just here so TypeScript can infer the types of the callbacks when using "on" method
     on(event, callback) {
         return this.emitter.on(event, callback);
     }

--- a/dist/main/pluginManager.js
+++ b/dist/main/pluginManager.js
@@ -91,7 +91,7 @@ class PluginManager {
     }
     consumeLinter(register) {
         const linter = register({
-            name: "Typescript",
+            name: "TypeScript",
         });
         this.errorPusher.setLinter(linter);
         this.clientResolver.on("diagnostics", ({ type, filePath, diagnostics }) => {

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -22,12 +22,12 @@ reasons. You can manually tell it to refresh by running
 
 Your current version installed in your `node_modules`. This gets
 determined once per open file so you might want to re-open your panes,
-if you've updated Typescript in your project.
+if you've updated TypeScript in your project.
 
-## Atom Typescript is complaining about not finding files or other weird errors
+## Atom TypeScript is complaining about not finding files or other weird errors
 
 You probably deleted them or added them or moved them around. The
-Typescript compiler is decent about keeping track of moving files, but
+TypeScript compiler is decent about keeping track of moving files, but
 sometimes things can go out of sync and in that case it's best to simply
 reset the editor using `Window: Reload` command.
 

--- a/lib/client/client.ts
+++ b/lib/client/client.ts
@@ -115,7 +115,7 @@ export class TypescriptServiceClient {
       if (this.lastStderrOutput) {
         detail = `Last output from tsserver:\n${this.lastStderrOutput}\n\n${detail}`
       }
-      atom.notifications.addError("Typescript quit unexpectedly", {
+      atom.notifications.addError("TypeScript quit unexpectedly", {
         detail,
         stack: err.stack,
         dismissable: true,

--- a/lib/client/clientResolver.ts
+++ b/lib/client/clientResolver.ts
@@ -40,7 +40,7 @@ export class ClientResolver {
   public clients = new Map<string, ClientRec>()
   private emitter = new Emitter<{}, EventTypes>()
 
-  // This is just here so Typescript can infer the types of the callbacks when using "on" method
+  // This is just here so TypeScript can infer the types of the callbacks when using "on" method
   public on<T extends keyof EventTypes>(event: T, callback: (result: EventTypes[T]) => void) {
     return this.emitter.on(event, callback)
   }

--- a/lib/main/pluginManager.ts
+++ b/lib/main/pluginManager.ts
@@ -94,7 +94,7 @@ export class PluginManager {
 
   public consumeLinter(register: (opts: {name: string}) => IndieDelegate) {
     const linter = register({
-      name: "Typescript",
+      name: "TypeScript",
     })
 
     this.errorPusher.setLinter(linter)

--- a/spec/package.spec.ts
+++ b/spec/package.spec.ts
@@ -9,7 +9,7 @@ describe("atom-typescript", function() {
   it("should activate", async () => {
     const packages = atom.packages
 
-    // Load package, but it won't activate until the Typescript grammar is used
+    // Load package, but it won't activate until the TypeScript grammar is used
     const promise = atom.packages.activatePackage(packagePath)
 
     packages.triggerActivationHook("language-typescript:grammar-used")


### PR DESCRIPTION
“Typescript” → “TypeScript”. All compiled assets are included.
