### PR TITLE
Update “failed to install” to be more accessible

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -109,7 +109,7 @@ instances and run the following commands:
 
 ## Failed to install
 
-Follow the same steps as specified in failed to update.
+Follow the same steps as specified in [failed to update](https://github.com/TypeStrong/atom-typescript/blob/master/docs/faq.md#failed-to-update).
 
 ## How can I contribute
 


### PR DESCRIPTION
Added link to “failed to update” so that if the user doesn’t read the entire thing but is instead scrolling through the faqs, they know what to click to get to the correct instructions.

- [ ] All compiled assets are included (atom packages are git tags and hence the built files need to be a part of the source control)

